### PR TITLE
Grandfather existing subscribers and show actual billing in admin

### DIFF
--- a/admin/license/index.php
+++ b/admin/license/index.php
@@ -35,7 +35,15 @@ function get_premium_subscriptions($search_filter = '')
 
     try {
         $query = "
-            SELECT s.*, u.username
+            SELECT s.*, u.username,
+                (
+                    SELECT p.amount
+                    FROM premium_subscription_payments p
+                    WHERE p.subscription_id = s.subscription_id
+                      AND p.status = 'completed'
+                    ORDER BY p.created_at DESC
+                    LIMIT 1
+                ) AS last_paid_amount
             FROM premium_subscriptions s
             LEFT JOIN community_users u ON s.user_id = u.id
             WHERE s.payment_method != 'free_key'
@@ -613,7 +621,13 @@ include __DIR__ . '/../admin_header.php';
                                         <td class="key-field"><?php echo htmlspecialchars($sub['subscription_id']); ?></td>
                                         <td><?php echo htmlspecialchars($sub['username'] ?? 'N/A'); ?></td>
                                         <td><?php echo htmlspecialchars($sub['email']); ?></td>
-                                        <td><?php echo ucfirst($sub['billing_cycle']); ?> - $<?php echo number_format($sub['amount'], 2); ?></td>
+                                        <?php
+                                            // Show what the customer is actually billed (most recent completed
+                                            // payment), not the env-computed snapshot in s.amount, which can
+                                            // differ (e.g. a PayPal plan priced below the configured amount).
+                                            $billedAmount = $sub['last_paid_amount'] ?? $sub['amount'];
+                                        ?>
+                                        <td><?php echo ucfirst($sub['billing_cycle']); ?> - $<?php echo number_format((float) $billedAmount, 2); ?></td>
                                         <td>
                                             <?php
                                             $providerNames = ['paypal' => 'PayPal', 'stripe' => 'Stripe', 'square' => 'Square'];

--- a/cron/subscription_renewal.php
+++ b/cron/subscription_renewal.php
@@ -117,8 +117,21 @@ foreach ($subscriptions as $subscription) {
 
     // Decide credit/charge split (and add processing fee). Single source of
     // truth lives in cron/lib/renewal_helpers.php so it can be unit-tested.
+    //
+    // Grandfathering: charge the base price locked at signup, not the current
+    // env price, so raising prices never re-prices existing customers. Legacy
+    // rows with no recorded signup_base_price fall back to the current env price.
     $pricingConfig = get_pricing_config();
-    $decision = decide_renewal_charge((float) $creditBalance, $billing, $pricingConfig);
+    $renewalConfig = $pricingConfig;
+    $lockedBase = $subscription['signup_base_price'] ?? null;
+    if ($lockedBase !== null && (float) $lockedBase > 0) {
+        if ($billing === 'yearly') {
+            $renewalConfig['premium_yearly_price'] = (float) $lockedBase;
+        } else {
+            $renewalConfig['premium_monthly_price'] = (float) $lockedBase;
+        }
+    }
+    $decision = decide_renewal_charge((float) $creditBalance, $billing, $renewalConfig);
     $useCredit = $decision['useCredit'];
     $creditUsed = $decision['creditUsed'];
     $amount = $decision['baseAmount'];

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -306,6 +306,7 @@ CREATE TABLE IF NOT EXISTS premium_subscriptions (
     email VARCHAR(100) DEFAULT NULL,
     billing_cycle ENUM('monthly', 'yearly') NOT NULL DEFAULT 'monthly',
     amount DECIMAL(10,2) NOT NULL,
+    signup_base_price DECIMAL(10,2) DEFAULT NULL COMMENT 'Base price (pre-processing-fee) locked at signup/cycle-switch. Renewals charge this so raising the env price never re-prices existing customers. NULL falls back to the current env price.',
     currency VARCHAR(3) NOT NULL DEFAULT 'CAD',
     start_date DATETIME NOT NULL,
     end_date DATETIME NOT NULL,

--- a/pricing/premium/checkout/process-subscription.php
+++ b/pricing/premium/checkout/process-subscription.php
@@ -529,6 +529,7 @@ try {
                     transaction_id = ?,
                     billing_cycle = ?,
                     amount = ?,
+                    signup_base_price = ?,
                     end_date = ?,
                     paypal_subscription_id = ?,
                     previous_paypal_subscription_id = ?,
@@ -545,6 +546,9 @@ try {
                 $stripeCustomerId,
                 $transactionId,
                 $billing,
+                $newAmount,
+                // Cycle switch is a deliberate plan change, so re-lock to the
+                // current price for the new cycle (not the old grandfathered one).
                 $newAmount,
                 $newEndDate,
                 $paypalSubscriptionId,
@@ -584,6 +588,7 @@ try {
                     transaction_id = ?,
                     billing_cycle = ?,
                     amount = ?,
+                    signup_base_price = ?,
                     end_date = ?,
                     status = 'active',
                     auto_renew = 1,
@@ -597,6 +602,8 @@ try {
                 $stripeCustomerId,
                 $transactionId,
                 $billing,
+                $newAmount,
+                // Re-lock to the current price for the new cycle.
                 $newAmount,
                 $newEndDate,
                 $subscriptionId
@@ -702,6 +709,23 @@ try {
             }
         }
 
+        // If this cycle switch raised the customer's effective rate (e.g. they
+        // had an older, lower locked-in price), say so plainly so a higher
+        // charge isn't a surprise. Compare monthly-equivalent rates, and only
+        // when we have a recorded old locked price to compare against.
+        $priceIncreaseNote = '';
+        $oldLockedBase = $existingSubscription['signup_base_price'] ?? null;
+        if ($oldLockedBase !== null && (float) $oldLockedBase > 0) {
+            $oldMonthly = ($existingSubscription['billing_cycle'] === 'yearly')
+                ? (float) $oldLockedBase / 12
+                : (float) $oldLockedBase;
+            $newMonthly = ($billing === 'yearly') ? (float) $newAmount / 12 : (float) $newAmount;
+            if ($newMonthly > $oldMonthly + 0.01) {
+                $newRateStr = '$' . number_format((float) $newAmount, 2) . '/' . ($billing === 'yearly' ? 'year' : 'month');
+                $priceIncreaseNote = " Note: changing your plan moves you to our current rate ($newRateStr). Your previous price was locked in when you first subscribed, and switching plans applies today's pricing.";
+            }
+        }
+
         // Build appropriate success message
         $formattedEndDate = date('F j, Y', strtotime($newEndDate));
         if ($isPayPalCycleSwitch) {
@@ -711,6 +735,7 @@ try {
         } else {
             $chargeMessage = "Payment successful! Your subscription is now active until $formattedEndDate.";
         }
+        $chargeMessage .= $priceIncreaseNote;
 
         $responseData = [
             'success' => true,
@@ -727,11 +752,11 @@ try {
         // Create new subscription
         $stmt = $pdo->prepare("
             INSERT INTO premium_subscriptions (
-                subscription_id, user_id, email, billing_cycle, amount, currency,
+                subscription_id, user_id, email, billing_cycle, amount, signup_base_price, currency,
                 start_date, end_date, status, payment_method, transaction_id,
                 payment_token, stripe_customer_id, auto_renew, environment, created_at
             ) VALUES (
-                ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?,
                 ?, ?, 'active', ?, ?,
                 ?, ?, 1, ?, NOW()
             )
@@ -743,6 +768,9 @@ try {
             $email,
             $billing,
             $amount,
+            // Lock the base price (pre-fee) at signup so future renewals charge
+            // this rate even if the env price changes later. Grandfathering.
+            $baseCharge,
             $currency,
             $startDate,
             $endDate,


### PR DESCRIPTION
## What this does

Two related billing fixes.

**1. Existing customers are never re-priced when the price changes.**
The renewal cron previously recomputed each charge from the live env price every cycle, so raising `PREMIUM_MONTHLY_PRICE` silently re-priced existing card customers on their next renewal (PayPal was already locked by its plan). Now each subscription's base price is locked at signup in a new `signup_base_price` column, and the renewal cron charges that instead of env. Raising the price only affects **new** customers. Legacy rows with no recorded base fall back to the env price.

- A billing-cycle switch is a deliberate plan change, so it re-locks to the current price for the new cycle.
- If a switch raises the customer's effective rate, the success message now explains why ("changing your plan moves you to our current rate… your previous price was locked in when you first subscribed").

**2. Admin license page shows actual billing.**
It now displays the most recent completed payment instead of the env-computed snapshot in `s.amount`, which can differ from what the gateway actually charged (e.g. a PayPal plan priced below the configured amount).

## Files
- `mysql_schema.sql` — new `signup_base_price` column
- `pricing/premium/checkout/process-subscription.php` — lock price at signup; re-lock + explain on cycle switch
- `cron/subscription_renewal.php` — charge the locked price, not env
- `admin/license/index.php` — display actual last completed payment

## Required before deploy

Run this SQL **before** deploying — the new-signup INSERT references `signup_base_price`, so checkout errors if the column is missing:

```sql
ALTER TABLE premium_subscriptions
  ADD COLUMN signup_base_price DECIMAL(10,2) DEFAULT NULL
    COMMENT 'Base price (pre-processing-fee) locked at signup/cycle-switch.'
  AFTER amount;

-- Backfill so existing customers stay grandfathered at what they pay now
UPDATE premium_subscriptions
SET signup_base_price = ROUND((amount - 0.30) / 1.029, 2)
WHERE signup_base_price IS NULL AND amount > 0;

-- Correct King's records to his actual $10 PayPal price (stale-plan bug)
UPDATE premium_subscriptions
SET amount = 10.00, signup_base_price = 10.00
WHERE subscription_id = 'PREM-OC8R-61PH-BAGM-OCHI';
UPDATE premium_subscription_payments
SET amount = 10.00
WHERE subscription_id = 'PREM-OC8R-61PH-BAGM-OCHI' AND payment_type = 'initial';
```

## Testing
- All four files lint clean (`php -l`).
- `decide_renewal_charge` is unchanged (it's just fed the locked base), so existing unit tests still hold.
- Not yet exercised at runtime — verify with a sandbox checkout + sandbox renewal before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)