### PR TITLE
Admin UI: high-contrast text, spell out MAU, drop data summary

### DIFF
--- a/admin/app-stats/index.php
+++ b/admin/app-stats/index.php
@@ -338,7 +338,7 @@ include __DIR__ . '/../admin_header.php';
 .stat-card h3 {
     font-size: 0.875rem;
     font-weight: 600;
-    color: #6b7280;
+    color: var(--black);
     margin: 0 0 0.5rem 0;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -347,13 +347,13 @@ include __DIR__ . '/../admin_header.php';
 .stat-card .value {
     font-size: 2rem;
     font-weight: 700;
-    color: #1f2937;
+    color: var(--black);
     margin: 0.5rem 0;
 }
 
 .stat-card .subtext {
     font-size: 0.75rem;
-    color: #9ca3af;
+    color: var(--black);
     margin: 0;
 }
 
@@ -364,7 +364,7 @@ include __DIR__ . '/../admin_header.php';
 .section-title {
     text-align: center;
     margin-bottom: 1.5rem;
-    color: #374151;
+    color: var(--black);
     font-size: 1.5rem;
     font-weight: 600;
 }
@@ -405,7 +405,7 @@ include __DIR__ . '/../admin_header.php';
 .error-details-table th {
     background: #f9fafb;
     font-weight: 600;
-    color: #374151;
+    color: var(--black);
     text-transform: uppercase;
     font-size: 0.75rem;
     letter-spacing: 0.05em;
@@ -426,7 +426,7 @@ include __DIR__ . '/../admin_header.php';
 .error-details-table td.error-source {
     font-family: monospace;
     font-size: 0.8rem;
-    color: #6b7280;
+    color: var(--black);
 }
 
 .error-details-wrapper {
@@ -473,12 +473,12 @@ include __DIR__ . '/../admin_header.php';
 }
 
 [data-theme="dark"] .tier-filter-label {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .tier-pill {
     background: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .tier-pill:hover {
@@ -543,23 +543,6 @@ include __DIR__ . '/../admin_header.php';
             <?php endif; ?>
         </div>
     <?php else: ?>
-        <div class="data-info">
-            <strong>Data Summary:</strong>
-            <?= $fileInfo['processed_files'] ?> files processed
-            (<?= $fileInfo['total_files'] ?> total files)
-            <?php if ($fileInfo['failed_files'] > 0): ?>
-                | <?= $fileInfo['failed_files'] ?> files failed to process
-            <?php endif; ?>
-            <?php if ($tierFilter !== 'all'): ?>
-                | <strong>Filter:</strong> <?= htmlspecialchars(ucfirst($tierFilter)) ?> tier only
-            <?php endif; ?>
-            <br>
-            <strong>Latest Data:</strong> <?= date('M j, Y g:i A', $fileInfo['latest_modified']) ?>
-            <?php if ($fileInfo['oldest_file'] !== $fileInfo['latest_file']): ?>
-                | <strong>Oldest Data:</strong> <?= date('M j, Y g:i A', $fileInfo['oldest_modified']) ?>
-            <?php endif; ?>
-        </div>
-
         <div class="tabs-container">
             <div class="section-tabs">
                 <button class="section-tab active" data-tab="active-users">Active Users</button>
@@ -604,12 +587,12 @@ include __DIR__ . '/../admin_header.php';
 
                 <div class="stats-grid">
                     <div class="stat-card">
-                        <h3>Free Users (MAU)</h3>
+                        <h3>Free Users (Monthly Active Users)</h3>
                         <div class="value"><?= number_format($aggregatedData['tierStats']['free']['mauUsers']) ?></div>
                         <p class="subtext"><?= number_format($aggregatedData['tierStats']['free']['totalUsers']) ?> total · last 30 days</p>
                     </div>
                     <div class="stat-card">
-                        <h3>Premium Users (MAU)</h3>
+                        <h3>Premium Users (Monthly Active Users)</h3>
                         <div class="value"><?= number_format($aggregatedData['tierStats']['premium']['mauUsers']) ?></div>
                         <p class="subtext"><?= number_format($aggregatedData['tierStats']['premium']['totalUsers']) ?> total · last 30 days</p>
                     </div>
@@ -894,7 +877,7 @@ include __DIR__ . '/../admin_header.php';
 
                 <h2 class="section-title" style="margin-top: 2rem;">Error Details</h2>
                 <div class="error-details-wrapper" id="errorDetailsTableWrapper">
-                    <p style="text-align: center; color: #9ca3af;">No error data available</p>
+                    <p style="text-align: center; color: var(--black);">No error data available</p>
                 </div>
             </div>
 

--- a/admin/app-stats/user-activity-tab.php
+++ b/admin/app-stats/user-activity-tab.php
@@ -185,7 +185,7 @@ if (!function_exists('ua_fmt')) {
 }
 if (!function_exists('ua_kv')) {
     function ua_kv($arr) {
-        if (!$arr) return '<span style="color:#9ca3af">none</span>';
+        if (!$arr) return '<span style="color:var(--black)">none</span>';
         arsort($arr);
         $out = [];
         foreach ($arr as $k => $v) $out[] = htmlspecialchars($k) . ' <b>' . $v . '</b>';
@@ -194,18 +194,18 @@ if (!function_exists('ua_kv')) {
 }
 ?>
 <style>
-.ua-intro { color:#6b7280; margin-bottom:1rem; }
+.ua-intro { color:var(--black); margin-bottom:1rem; }
 .ua-flash { background:#ecfdf5; border:1px solid #6ee7b7; color:#065f46; padding:10px 14px; border-radius:8px; margin-bottom:1rem; }
 .ua-card { border:1px solid #e5e7eb; border-radius:10px; padding:1rem 1.25rem; margin-bottom:1rem; background:#fff; }
 .ua-card h3 { margin:0 0 .25rem; font-family:monospace; font-size:1rem; word-break:break-all; }
 .ua-badge { display:inline-block; font-size:.7rem; font-weight:700; text-transform:uppercase; padding:2px 8px; border-radius:999px; margin-left:.5rem; vertical-align:middle; }
 .ua-badge.free { background:#dbeafe; color:#1e40af; }
 .ua-badge.premium { background:#fef3c7; color:#92400e; }
-.ua-meta { color:#374151; font-size:.85rem; margin:.4rem 0; }
+.ua-meta { color:var(--black); font-size:.85rem; margin:.4rem 0; }
 .ua-meta span { display:inline-block; margin-right:1.25rem; }
 .ua-row { font-size:.85rem; margin:.25rem 0; }
-.ua-row b { color:#111827; }
-.ua-files { font-family:monospace; font-size:.7rem; color:#9ca3af; margin-top:.5rem; word-break:break-all; }
+.ua-row b { color:var(--black); }
+.ua-files { font-family:monospace; font-size:.7rem; color:var(--black); margin-top:.5rem; word-break:break-all; }
 .ua-del { float:right; }
 .ua-del button { background:#ef4444; color:#fff; border:0; border-radius:6px; padding:6px 12px; font-size:.8rem; cursor:pointer; }
 .ua-del button:hover { background:#dc2626; }
@@ -214,15 +214,15 @@ if (!function_exists('ua_kv')) {
 .ua-timeline { margin-top:.5rem; max-height:340px; overflow-y:auto; border:1px solid #e5e7eb; border-radius:8px; }
 .ua-evt { display:flex; gap:.75rem; padding:5px 12px; font-size:.78rem; border-bottom:1px solid #f3f4f6; }
 .ua-evt:last-child { border-bottom:0; }
-.ua-evt-ts { color:#9ca3af; font-family:monospace; white-space:nowrap; }
-.ua-evt-text { color:#374151; }
+.ua-evt-ts { color:var(--black); font-family:monospace; white-space:nowrap; }
+.ua-evt-text { color:var(--black); }
 .ua-evt.error  .ua-evt-text { color:#b91c1c; font-family:monospace; }
 .ua-evt.api    .ua-evt-text { color:#7c3aed; }
 .ua-evt.export .ua-evt-text { color:#0369a1; }
 .ua-evt.feature .ua-evt-text { color:#047857; }
-.ua-evt.session .ua-evt-text { color:#6b7280; }
+.ua-evt.session .ua-evt-text { color:var(--black); }
 [data-theme="dark"] .ua-card { background:var(--gray-800); border-color:var(--gray-700); }
-[data-theme="dark"] .ua-card h3, [data-theme="dark"] .ua-meta, [data-theme="dark"] .ua-row, [data-theme="dark"] .ua-row b, [data-theme="dark"] .ua-evt-text { color:var(--gray-200); }
+[data-theme="dark"] .ua-card h3, [data-theme="dark"] .ua-meta, [data-theme="dark"] .ua-row, [data-theme="dark"] .ua-row b, [data-theme="dark"] .ua-evt-text { color:var(--white); }
 [data-theme="dark"] .ua-timeline { border-color:var(--gray-700); }
 [data-theme="dark"] .ua-evt { border-bottom-color:var(--gray-700); }
 </style>

--- a/admin/common-style.css
+++ b/admin/common-style.css
@@ -239,7 +239,7 @@ body.menu-open::after {
 .header-title {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--dark-gray);
+  color: var(--black);
 }
 
 /* Desktop Navigation */
@@ -263,7 +263,7 @@ body.menu-open::after {
 }
 
 .header-link:hover {
-  color: var(--dark-gray);
+  color: var(--black);
   background: var(--neutral-f0f0f0);
 }
 
@@ -348,7 +348,7 @@ body.menu-open::after {
 }
 
 .nav-dropdown-link:hover {
-  color: var(--dark-gray);
+  color: var(--black);
   background: var(--neutral-f0f0f0);
 }
 
@@ -429,7 +429,7 @@ body.menu-open::after {
 .page-title {
   font-size: 1.75rem;
   font-weight: 600;
-  color: var(--dark-gray);
+  color: var(--black);
   margin: 0 0 0.5rem 0;
 }
 
@@ -638,7 +638,7 @@ tbody tr:hover {
 }
 
 .stat-card .subtext {
-  color: var(--gray-placeholder);
+  color: var(--black);
   font-size: 0.75rem;
   margin-top: 0.25rem;
   line-height: 1.2;
@@ -1001,7 +1001,7 @@ tbody tr:hover {
   padding: 1rem;
   margin-bottom: 1.5rem;
   text-align: center;
-  color: var(--gray-600);
+  color: var(--black);
   font-size: 0.875rem;
   font-weight: 500;
 }
@@ -1265,13 +1265,13 @@ tbody tr:hover {
    ============================================================ */
 [data-theme="dark"] .theme-toggle {
   border-color: var(--black);
-  color: var(--gray-input-border);
+  color: var(--white);
 }
 
 [data-theme="dark"] .theme-toggle:hover {
   background: var(--gray-700);
   border-color: var(--black);
-  color: var(--whiteBackground);
+  color: var(--white);
 }
 
 [data-theme="dark"] .theme-toggle .icon-moon {
@@ -1294,7 +1294,7 @@ tbody tr:hover {
 
 [data-theme="dark"] body {
   background: var(--neutral-111827);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 /* Dark theme - Header */
@@ -1305,15 +1305,15 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .header-title {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 [data-theme="dark"] .header-link {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .header-link:hover {
-  color: var(--gray-200);
+  color: var(--white);
   background: var(--gray-700);
 }
 
@@ -1329,11 +1329,11 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .nav-dropdown-link {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .nav-dropdown-link:hover {
-  color: var(--gray-200);
+  color: var(--white);
   background: var(--gray-700);
 }
 
@@ -1343,7 +1343,7 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .user-name {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .menu-icon .nav-icon,
@@ -1359,13 +1359,13 @@ tbody tr:hover {
 /* Dark theme - Home button */
 [data-theme="dark"] .btn-home {
   background: var(--gray-700);
-  color: var(--gray-400);
+  color: var(--white);
   border-color: var(--gray-600);
 }
 
 [data-theme="dark"] .btn-home:hover {
   background: var(--slate-3f4f63);
-  color: var(--gray-200);
+  color: var(--white);
   border-color: var(--gray-500);
 }
 
@@ -1383,7 +1383,7 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .hamburger-nav-menu ul li a {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .hamburger-nav-menu ul li a:hover {
@@ -1405,11 +1405,11 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .page-title {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 [data-theme="dark"] .page-description {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 /* Dark theme - Typography */
@@ -1418,11 +1418,11 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] h2 {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] h3 {
-  color: var(--gray-300);
+  color: var(--white);
 }
 
 /* Dark theme - Tables */
@@ -1434,13 +1434,13 @@ tbody tr:hover {
 
 [data-theme="dark"] th {
   background-color: var(--gray-800);
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] th,
 [data-theme="dark"] td {
   border-bottom-color: var(--black);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] tbody tr:hover {
@@ -1455,7 +1455,7 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .stat-card h3 {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .stat-card .stat-value,
@@ -1464,7 +1464,7 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .stat-card .subtext {
-  color: var(--gray-500);
+  color: var(--white);
 }
 
 /* Dark theme - Charts */
@@ -1475,7 +1475,7 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .chart-no-data {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 /* Dark theme - Forms & Inputs */
@@ -1487,12 +1487,12 @@ tbody tr:hover {
 [data-theme="dark"] textarea {
   background: var(--gray-700);
   border-color: var(--black);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] input::placeholder,
 [data-theme="dark"] textarea::placeholder {
-  color: var(--gray-500);
+  color: var(--white);
 }
 
 [data-theme="dark"] input[type="password"]::-ms-reveal {
@@ -1500,7 +1500,7 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] label {
-  color: var(--gray-300);
+  color: var(--white);
 }
 
 /* Dark theme - Badges */
@@ -1521,7 +1521,7 @@ tbody tr:hover {
 
 [data-theme="dark"] .badge-user {
   background-color: var(--gray-alpha-30);
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .badge-banned {
@@ -1531,7 +1531,7 @@ tbody tr:hover {
 
 [data-theme="dark"] .badge-active {
   background-color: var(--gray-alpha-20);
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 /* Dark theme - Alerts */
@@ -1556,12 +1556,12 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .period-selection span {
-  color: var(--gray-300);
+  color: var(--white);
 }
 
 [data-theme="dark"] .period-btn {
   background: var(--gray-700);
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .period-btn:hover {
@@ -1570,7 +1570,7 @@ tbody tr:hover {
 
 [data-theme="dark"] .period-btn.active {
   background: var(--gray-600);
-  color: var(--gray-100);
+  color: var(--white);
   border-color: var(--black);
 }
 
@@ -1578,14 +1578,14 @@ tbody tr:hover {
 [data-theme="dark"] .range-select select,
 [data-theme="dark"] .range-custom input[type="date"] {
   background: var(--gray-800);
-  color: var(--gray-100);
+  color: var(--white);
   border-color: var(--gray-700);
   box-shadow: 0 1px 3px var(--overlay-light);
 }
 
 [data-theme="dark"] .range-label,
 [data-theme="dark"] .range-display {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 [data-theme="dark"] .range-custom input[type="date"] {
@@ -1606,40 +1606,40 @@ tbody tr:hover {
 [data-theme="dark"] .secret-key {
   background: var(--gray-700);
   border-color: var(--black);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .verification-heading {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .verification-code,
 [data-theme="dark"] .verification-input {
   background: var(--gray-700);
   border-color: var(--black);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 /* Dark theme - Data info / No data */
 [data-theme="dark"] .data-info {
   background: linear-gradient(135deg, var(--gray-800) 0%, var(--gray-700) 100%);
   border-color: var(--gray-600);
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .no-data {
-  color: var(--gray-400);
+  color: var(--white);
   background: linear-gradient(135deg, var(--gray-800) 0%, var(--gray-800) 100%);
   border-color: var(--gray-600);
 }
 
 [data-theme="dark"] .no-data h3 {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .no-data code {
   background: var(--gray-700);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 /* Dark theme - Scrollbar */
@@ -1668,11 +1668,11 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .env-toggle-btn {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .env-toggle-btn:hover {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .env-toggle-btn.active {
@@ -1685,11 +1685,11 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .section-tab {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .section-tab:hover {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 /* Dark theme - Payment status badges */
@@ -1715,7 +1715,7 @@ tbody tr:hover {
 [data-theme="dark"] .badge-invoice-draft,
 [data-theme="dark"] .badge-invoice-cancelled {
   background: var(--gray-alpha-20);
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .badge-invoice-sent {
@@ -1764,16 +1764,16 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .detail-section-title {
-  color: var(--gray-300);
+  color: var(--white);
   border-bottom-color: var(--black);
 }
 
 [data-theme="dark"] .detail-label {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .detail-value {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .provider-card {
@@ -1791,11 +1791,11 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .provider-card-name {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .provider-card-status {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .expandable-row:hover {
@@ -1813,24 +1813,24 @@ tbody tr:hover {
 
 [data-theme="dark"] .provider-badge.disconnected {
   background-color: var(--gray-alpha-20);
-  color: var(--gray-500);
+  color: var(--white);
 }
 
 /* Dark theme - Result count */
 [data-theme="dark"] .result-count {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 /* Dark theme - Btn outline */
 [data-theme="dark"] .btn-outline {
   background: var(--gray-700);
-  color: var(--gray-400);
+  color: var(--white);
   border-color: var(--black);
 }
 
 [data-theme="dark"] .btn-outline:hover {
   background: var(--gray-600);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 /* Dark theme - Badge method */
@@ -1841,11 +1841,11 @@ tbody tr:hover {
 
 /* Dark theme - License page */
 [data-theme="dark"] .form-group label {
-  color: var(--gray-300);
+  color: var(--white);
 }
 
 [data-theme="dark"] .form-group small {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .form-group input,
@@ -1853,7 +1853,7 @@ tbody tr:hover {
 [data-theme="dark"] .form-group textarea {
   background: var(--gray-700);
   border-color: var(--black);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .key-display {
@@ -1883,20 +1883,20 @@ tbody tr:hover {
 
 [data-theme="dark"] .badge-expired {
   background: var(--gray-alpha-20);
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .usage-count {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .usage-na {
-  color: var(--gray-500);
+  color: var(--white);
 }
 
 [data-theme="dark"] .btn-secondary {
   background: var(--gray-700);
-  color: var(--gray-200);
+  color: var(--white);
   border-color: var(--black);
 }
 
@@ -1914,24 +1914,24 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .modal-header h3 {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 [data-theme="dark"] .modal-close {
-  color: var(--gray-500);
+  color: var(--white);
 }
 
 [data-theme="dark"] .modal-close:hover {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .modal-body p {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .modal-note {
   background: var(--gray-700);
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .modal-footer {
@@ -1940,7 +1940,7 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] #modalTitle {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 /* Dark theme - Referral links page */
@@ -1949,7 +1949,7 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] table td {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] table tbody tr:hover {
@@ -1982,20 +1982,20 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .report-title {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 [data-theme="dark"] .report-id {
-  color: var(--gray-500);
+  color: var(--white);
 }
 
 [data-theme="dark"] .report-meta-row {
-  color: var(--gray-500);
+  color: var(--white);
 }
 
 [data-theme="dark"] .content-preview {
   background: var(--gray-800);
-  color: var(--gray-400);
+  color: var(--white);
   border-left-color: var(--gray-600);
 }
 
@@ -2009,22 +2009,22 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .status-badge-label {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .status-badge-count {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 /* Dark theme - Filter groups */
 [data-theme="dark"] .filter-group select {
   background: var(--gray-700);
   border-color: var(--black);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .filter-group label {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 
@@ -2039,23 +2039,23 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .card-header h2 {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 [data-theme="dark"] .search-input {
   background: var(--gray-700);
   border-color: var(--black);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .clear-button {
   background: var(--gray-700);
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .clear-button:hover {
   background: var(--gray-600);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 /* Dark theme - Bulk actions (users) */
@@ -2065,7 +2065,7 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .selection-info {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 /* Dark theme - Dashboard chart cards */
@@ -2076,12 +2076,12 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .chart-card-title {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 /* Dark theme - Search results */
 [data-theme="dark"] .search-results {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 /* Dark theme - Checkboxes */
@@ -2100,7 +2100,7 @@ tbody tr:hover {
 
 /* Dark theme - Dashboard hero */
 [data-theme="dark"] .hero-section h1 {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 /* Dark theme - Env toggle production/sandbox */
@@ -2119,12 +2119,12 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .bulk-actions-container .selection-info {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 /* Dark theme - App stats inline styles */
 [data-theme="dark"] .section-title {
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .error-details-table {
@@ -2134,12 +2134,12 @@ tbody tr:hover {
 
 [data-theme="dark"] .error-details-table th {
   background: var(--gray-800);
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .error-details-table td {
   border-bottom-color: var(--black);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .error-details-table tr:hover {
@@ -2151,7 +2151,7 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .error-details-table td.error-source {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 /* ─── Pagination Controls ─── */
@@ -2194,7 +2194,7 @@ tbody tr:hover {
   border: none;
   border-radius: 6px;
   background: transparent;
-  color: var(--dark-gray, #374151);
+  color: var(--black);
   font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
@@ -2228,13 +2228,13 @@ tbody tr:hover {
   justify-content: center;
   min-width: 32px;
   height: 36px;
-  color: var(--gray-500);
+  color: var(--black);
   font-size: 0.9rem;
 }
 
 [data-theme="dark"] .pg-arrow,
 [data-theme="dark"] .pg-num {
-  color: var(--gray-300, #d1d5db);
+  color: var(--white);
 }
 
 [data-theme="dark"] .pg-arrow:hover:not(:disabled),
@@ -2306,11 +2306,11 @@ tbody tr:hover {
 }
 
 [data-theme="dark"] .section-tab {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 [data-theme="dark"] .section-tab:hover {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .section-tab.active {

--- a/admin/crons/style.css
+++ b/admin/crons/style.css
@@ -22,7 +22,7 @@
     padding: 6px 14px;
     border-radius: 6px;
     font-size: 13px;
-    color: var(--gray-700);
+    color: var(--black);
     text-decoration: none;
     transition: background 0.15s ease, color 0.15s ease;
 }
@@ -37,7 +37,7 @@
 }
 
 [data-theme="dark"] .range-btn {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .range-btn:hover {
@@ -55,12 +55,12 @@
     border: 1px dashed var(--gray-300);
     border-radius: 8px;
     text-align: center;
-    color: var(--gray-600);
+    color: var(--black);
 }
 
 [data-theme="dark"] .empty-state {
     border-color: var(--gray-700);
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 .cron-cards {
@@ -122,7 +122,7 @@
     height: 18px;
     border-radius: 999px;
     background: var(--gray-200);
-    color: var(--gray-700);
+    color: var(--black);
     font-family: 'Times New Roman', serif;
     font-style: italic;
     font-size: 12px;
@@ -139,7 +139,7 @@
 
 [data-theme="dark"] .cron-info-icon {
     background: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .cron-info:hover .cron-info-icon,
@@ -203,11 +203,11 @@
     flex-wrap: wrap;
     gap: 12px;
     font-size: 12px;
-    color: var(--gray-600);
+    color: var(--black);
 }
 
 [data-theme="dark"] .cron-meta {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 
@@ -236,14 +236,14 @@
     padding: 12px;
     background: var(--gray-100, #f9fafb);
     border-radius: 6px;
-    color: var(--gray-600);
+    color: var(--black);
     font-size: 13px;
     text-align: center;
 }
 
 [data-theme="dark"] .cron-empty {
     background: var(--gray-900);
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 .cron-metrics {
@@ -270,12 +270,12 @@
 
 .metric-label {
     font-size: 12px;
-    color: var(--gray-600);
+    color: var(--black);
     margin-top: 4px;
 }
 
 [data-theme="dark"] .metric-label {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 .cron-detail {
@@ -291,11 +291,11 @@
 .cron-detail summary {
     cursor: pointer;
     font-size: 13px;
-    color: var(--gray-600);
+    color: var(--black);
 }
 
 [data-theme="dark"] .cron-detail summary {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 .cron-detail summary:hover {
@@ -335,7 +335,7 @@
 }
 
 .cron-metric-table td.k {
-    color: var(--gray-600);
+    color: var(--black);
     width: 40%;
 }
 
@@ -346,5 +346,5 @@
 }
 
 [data-theme="dark"] .cron-metric-table td.k {
-    color: var(--gray-400);
+    color: var(--white);
 }

--- a/admin/license/index.php
+++ b/admin/license/index.php
@@ -470,7 +470,7 @@ include __DIR__ . '/../admin_header.php';
     padding: 2px 8px;
     font-size: 12px;
     font-weight: 500;
-    color: #6b7280;
+    color: var(--black);
     background: #f3f4f6;
     border: 1px solid #d1d5db;
     border-radius: 4px;
@@ -482,7 +482,7 @@ include __DIR__ . '/../admin_header.php';
 }
 .btn-copy:hover {
     background: #e5e7eb;
-    color: #374151;
+    color: var(--black);
 }
 .btn-copy.copied {
     background: #d1fae5;
@@ -491,12 +491,12 @@ include __DIR__ . '/../admin_header.php';
 }
 [data-theme="dark"] .btn-copy {
     background: #1e293b;
-    color: #94a3b8;
+    color: var(--white);
     border-color: #334155;
 }
 [data-theme="dark"] .btn-copy:hover {
     background: #334155;
-    color: #e2e8f0;
+    color: var(--white);
 }
 [data-theme="dark"] .btn-copy.copied {
     background: #064e3b;
@@ -737,7 +737,7 @@ include __DIR__ . '/../admin_header.php';
                     <div class="form-group">
                         <label for="notes">Notes (optional)</label>
                         <input type="text" id="notes" name="notes" placeholder="e.g., Giveaway winner">
-                         <p style="position: absolute; margin: 5px 0 20px; color: var(--gray-500);">This will also appear in the recipient's email.</p>
+                         <p style="position: absolute; margin: 5px 0 20px; color: var(--black);">This will also appear in the recipient's email.</p>
                     </div>
                     <div class="form-group">
                         <button type="submit" name="generate_sub_key" class="btn btn-purple" style="margin-top: 24px;">Generate Key</button>
@@ -805,7 +805,7 @@ include __DIR__ . '/../admin_header.php';
                                             <button type="button" class="btn-copy" onclick="copyToClipboard('<?php echo htmlspecialchars($key['subscription_key'], ENT_QUOTES); ?>', this)" title="Copy key">Copy</button>
                                         </td>
                                         <td><?php echo $key['duration_months'] == 0 ? '<span style="color:#8b5cf6;font-weight:500;">Permanent</span>' : $key['duration_months'] . ' month' . ($key['duration_months'] > 1 ? 's' : ''); ?></td>
-                                        <td><?php echo $key['email'] ? htmlspecialchars($key['email']) : '<span style="color:#9ca3af;">Any user</span>'; ?></td>
+                                        <td><?php echo $key['email'] ? htmlspecialchars($key['email']) : '<span style="color:var(--black);">Any user</span>'; ?></td>
                                         <td>
                                             <?php if ($key['redeemed_at']): ?>
                                                 <span class="badge badge-redeemed">Redeemed</span>

--- a/admin/license/style.css
+++ b/admin/license/style.css
@@ -123,13 +123,13 @@ table th {
 .modal-header h3 {
     margin: 0;
     font-size: 1.25rem;
-    color: var(--neutral-111827);
+    color: var(--black);
 }
 .modal-close {
     background: none;
     border: none;
     font-size: 1.5rem;
-    color: var(--gray-placeholder);
+    color: var(--black);
     cursor: pointer;
     padding: 0;
     line-height: 1;
@@ -174,7 +174,7 @@ table th {
 .usage-count {
     font-size: 0.875rem;
     font-weight: 500;
-    color: var(--gray-700);
+    color: var(--black);
     white-space: nowrap;
 }
 .usage-maxed {
@@ -182,7 +182,7 @@ table th {
     font-weight: 600;
 }
 .usage-na {
-    color: var(--gray-400);
+    color: var(--black);
 }
 .btn-reset-usage {
     background-color: var(--primary-blue);

--- a/admin/marketing-funnel/style.css
+++ b/admin/marketing-funnel/style.css
@@ -56,12 +56,12 @@
 }
 
 [data-theme="dark"] .funnel-controls .control-label {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .funnel-pill {
     background: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .funnel-pill:hover {
@@ -104,7 +104,7 @@
     top: 50%;
     transform: translateY(-50%);
     font-size: 11px;
-    color: var(--gray-500);
+    color: var(--black);
     pointer-events: auto;
     cursor: pointer;
 }
@@ -156,7 +156,7 @@
 [data-theme="dark"] .source-combobox-input {
     background: var(--gray-700);
     border-color: var(--black);
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .source-combobox-input:focus {
@@ -170,7 +170,7 @@
 }
 
 [data-theme="dark"] .source-combobox-option {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .source-combobox-option:hover,
@@ -218,7 +218,7 @@
 }
 
 [data-theme="dark"] .funnel-container h2 {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .funnel-container h2 .source-tag {
@@ -246,7 +246,7 @@
 }
 
 [data-theme="dark"] .funnel-label {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 .funnel-bar-wrap {
@@ -285,7 +285,7 @@
 }
 
 [data-theme="dark"] .funnel-count {
-    color: var(--gray-100);
+    color: var(--white);
 }
 
 .funnel-dropoff {
@@ -294,12 +294,12 @@
     gap: 12px;
     padding: 6px 0 6px 220px;
     font-size: 13px;
-    color: var(--gray-500);
+    color: var(--black);
 }
 
 .funnel-dropoff .kept { color: var(--emerald-600); font-weight: 600; }
-.funnel-dropoff .lost { color: var(--gray-400); }
-.funnel-dropoff .sep  { color: var(--gray-300); }
+.funnel-dropoff .lost { color: var(--black); }
+.funnel-dropoff .sep  { color: var(--black); }
 
 .funnel-dropoff.biggest { color: var(--red-600); }
 .funnel-dropoff.biggest .kept { color: var(--red-600); }
@@ -309,9 +309,9 @@
     color: var(--red-600);
 }
 
-[data-theme="dark"] .funnel-dropoff       { color: var(--gray-500); }
+[data-theme="dark"] .funnel-dropoff       { color: var(--white); }
 [data-theme="dark"] .funnel-dropoff .kept { color: var(--emerald-400); }
-[data-theme="dark"] .funnel-dropoff .lost { color: var(--gray-500); }
+[data-theme="dark"] .funnel-dropoff .lost { color: var(--white); }
 [data-theme="dark"] .funnel-dropoff.biggest { color: var(--red-400); }
 [data-theme="dark"] .funnel-dropoff.biggest .kept { color: var(--red-400); }
 [data-theme="dark"] .funnel-dropoff.biggest::before { color: var(--red-400); }
@@ -330,7 +330,7 @@
 
 .stat-card.hero .suffix {
     font-size: 13px;
-    color: var(--gray-500);
+    color: var(--black);
     margin-left: 8px;
     font-weight: 500;
 }
@@ -367,7 +367,7 @@
 [data-theme="dark"] .stat-card.ratio-profitable .value { color: var(--emerald-400); }
 [data-theme="dark"] .stat-card.ratio-organic .value    { color: var(--emerald-400); }
 
-[data-theme="dark"] .stat-card.hero .suffix { color: var(--gray-400); }
+[data-theme="dark"] .stat-card.hero .suffix { color: var(--white); }
 
 /* ─── Comparison table ─────────────────────────────────────────────────── */
 
@@ -400,7 +400,7 @@
 .empty-state {
     text-align: center;
     padding: 48px 24px;
-    color: var(--gray-500);
+    color: var(--black);
 }
 
 .empty-state p {
@@ -424,11 +424,11 @@
     margin: 0 0 16px 0;
     font-size: 15px;
     font-weight: 600;
-    color: var(--gray-600);
+    color: var(--black);
 }
 
 [data-theme="dark"] .landing-breakdown h3 {
-    color: var(--gray-300);
+    color: var(--white);
 }
 
 .landing-breakdown-body {
@@ -490,12 +490,12 @@
 
 .landing-breakdown-list .pct {
     font-variant-numeric: tabular-nums;
-    color: var(--gray-700);
+    color: var(--black);
     font-weight: 600;
 }
 
 [data-theme="dark"] .landing-breakdown-list .pct {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 /* ─── Modal (ad-spend create/edit) ─────────────────────────────────────── */
@@ -522,7 +522,7 @@
 }
 
 .modal-close {
-    color: var(--gray-placeholder);
+    color: var(--black);
     float: right;
     font-size: 32px;
     font-weight: bold;
@@ -541,7 +541,7 @@
 }
 
 [data-theme="dark"] #spendModalTitle {
-    color: var(--gray-100);
+    color: var(--white);
 }
 
 /* The month picker and textarea aren't covered by the shared input sizing
@@ -588,13 +588,13 @@
    button renders light-on-dark without this. */
 [data-theme="dark"] #spendModal .btn-gray {
     background-color: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
     border-color: var(--black);
 }
 
 [data-theme="dark"] #spendModal .btn-gray:hover {
     background-color: var(--gray-600);
-    color: var(--gray-100);
+    color: var(--white);
 }
 
 /* ─── Mobile responsive ────────────────────────────────────────────────── */
@@ -643,13 +643,13 @@
 .survey-other-details summary {
     cursor: pointer;
     font-size: 13px;
-    color: var(--gray-700);
+    color: var(--black);
     user-select: none;
     margin-bottom: 8px;
 }
 
 [data-theme="dark"] .survey-other-details summary {
-    color: var(--gray-300);
+    color: var(--white);
 }
 
 .survey-other-list {
@@ -680,10 +680,10 @@
 
 .survey-other-list .count {
     font-variant-numeric: tabular-nums;
-    color: var(--gray-600);
+    color: var(--black);
     flex-shrink: 0;
 }
 
 [data-theme="dark"] .survey-other-list .count {
-    color: var(--gray-400);
+    color: var(--white);
 }

--- a/admin/marketing/index.php
+++ b/admin/marketing/index.php
@@ -142,7 +142,7 @@ include __DIR__ . '/../admin_header.php';
   width:100%;padding:10px 12px;border:1px solid var(--border-color,#d8e2f0);border-radius:8px;
   font:500 14px/1.5 inherit;background:var(--input-bg,#fff);color:inherit;box-sizing:border-box}
 .mkt-field textarea{min-height:240px;font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px}
-.mkt-hint{font-size:12.5px;color:var(--text-muted,#6b7280);margin-top:5px}
+.mkt-hint{font-size:12.5px;color:var(--black);margin-top:5px}
 .mkt-actions{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
 .mkt-test{display:flex;gap:8px;flex:1;min-width:240px}
 .mkt-test input{flex:1}
@@ -150,7 +150,7 @@ include __DIR__ . '/../admin_header.php';
 .mkt-badge.queued{background:#fef3c7;color:#92400e}
 .mkt-badge.sending{background:#dbeafe;color:#1e40af}
 .mkt-badge.sent{background:#dcfce7;color:#166534}
-.mkt-badge.canceled{background:#f3f4f6;color:#6b7280}
+.mkt-badge.canceled{background:#f3f4f6;color:var(--black)}
 
 /* Dark theme. The base input rule hardcodes a light background and the shared
    .btn-gray / .mkt-hint colors have no dark variant, so override them here to
@@ -159,12 +159,12 @@ include __DIR__ . '/../admin_header.php';
 [data-theme="dark"] .mkt-field input[type=email],
 [data-theme="dark"] .mkt-field select,
 [data-theme="dark"] .mkt-field textarea{
-  background:var(--gray-700);border-color:var(--black);color:var(--gray-200)}
+  background:var(--gray-700);border-color:var(--black);color:var(--white)}
 [data-theme="dark"] .mkt-field input::placeholder,
-[data-theme="dark"] .mkt-field textarea::placeholder{color:var(--gray-500)}
-[data-theme="dark"] .mkt-hint{color:var(--gray-400)}
-[data-theme="dark"] .btn-gray{background-color:var(--gray-700);color:var(--gray-200);border-color:var(--black)}
-[data-theme="dark"] .btn-gray:hover{background-color:var(--gray-600);color:var(--gray-100)}
+[data-theme="dark"] .mkt-field textarea::placeholder{color:var(--white)}
+[data-theme="dark"] .mkt-hint{color:var(--white)}
+[data-theme="dark"] .btn-gray{background-color:var(--gray-700);color:var(--white);border-color:var(--black)}
+[data-theme="dark"] .btn-gray:hover{background-color:var(--gray-600);color:var(--white)}
 </style>
 
 <?php if ($flash): ?>

--- a/admin/outreach/style.css
+++ b/admin/outreach/style.css
@@ -20,7 +20,7 @@
 
 .stat-label {
     font-size: 12px;
-    color: var(--gray-500);
+    color: var(--black);
     text-transform: uppercase;
     font-weight: 500;
 }
@@ -28,7 +28,7 @@
 .stat-value {
     font-size: 22px;
     font-weight: 700;
-    color: var(--gray-800);
+    color: var(--black);
 }
 
 .stat-new { color: var(--blue-500); }
@@ -67,7 +67,7 @@
 }
 
 .panel-toggle {
-    color: var(--gray-400);
+    color: var(--black);
     font-size: 12px;
 }
 
@@ -108,7 +108,7 @@
 .form-group label {
     font-size: 13px;
     font-weight: 500;
-    color: var(--gray-700);
+    color: var(--black);
 }
 
 .form-group input,
@@ -120,7 +120,7 @@
     font-size: 14px;
     font-family: inherit;
     background: var(--white);
-    color: var(--gray-800);
+    color: var(--black);
 }
 
 .form-group input:focus,
@@ -167,19 +167,19 @@
     gap: 10px;
     padding: 8px 20px;
     font-size: 13px;
-    color: var(--gray-500);
+    color: var(--black);
     background: var(--blue-50);
     border-bottom: 1px solid var(--gray-border);
 }
 
 [data-theme="dark"] .bulk-draft-progress {
     background: var(--navy-1e3a5f);
-    color: var(--gray-300);
+    color: var(--white);
 }
 
 [data-theme="dark"] .bulk-draft-progress .btn-small {
     background: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
     border-color: var(--gray-600);
 }
 
@@ -239,7 +239,7 @@
     font-weight: 600;
     font-size: 12px;
     text-transform: uppercase;
-    color: var(--gray-500);
+    color: var(--black);
     border-bottom: 2px solid var(--gray-border);
     white-space: nowrap;
 }
@@ -272,17 +272,17 @@
 .empty-state {
     text-align: center;
     padding: 30px;
-    color: var(--gray-400);
+    color: var(--black);
 }
 
 .empty-state-text {
     text-align: center;
-    color: var(--gray-400);
+    color: var(--black);
     padding: 20px;
 }
 
 .text-muted {
-    color: var(--gray-400);
+    color: var(--black);
 }
 
 /* ─── Badges ─── */
@@ -341,7 +341,7 @@
 
 .filter-group label {
     font-size: 12px;
-    color: var(--gray-500);
+    color: var(--black);
     font-weight: 500;
 }
 
@@ -353,7 +353,7 @@
     font-size: 13px;
     min-width: 130px;
     background: var(--white);
-    color: var(--gray-800);
+    color: var(--black);
 }
 
 /* ─── Modals ─── */
@@ -401,13 +401,13 @@
     border: none;
     font-size: 22px;
     cursor: pointer;
-    color: var(--gray-400);
+    color: var(--black);
     padding: 0 4px;
     line-height: 1;
 }
 
 .modal-close:hover {
-    color: var(--gray-800);
+    color: var(--black);
 }
 
 .modal-body {
@@ -436,7 +436,7 @@
     border: none;
     font-size: 14px;
     font-weight: 500;
-    color: var(--gray-500);
+    color: var(--black);
     cursor: pointer;
     border-bottom: 2px solid transparent;
     margin-bottom: -2px;
@@ -444,7 +444,7 @@
 }
 
 .tab:hover {
-    color: var(--gray-700);
+    color: var(--black);
 }
 
 .tab.active {
@@ -565,12 +565,12 @@
 }
 
 .activity-details {
-    color: var(--gray-500);
+    color: var(--black);
     font-size: 12px;
 }
 
 .activity-time {
-    color: var(--gray-400);
+    color: var(--black);
     font-size: 11px;
 }
 
@@ -651,7 +651,7 @@
 .bulk-send-status {
     padding: 12px 20px;
     font-size: 0.9rem;
-    color: var(--gray-600);
+    color: var(--black);
     border-bottom: 1px solid var(--gray-border);
 }
 
@@ -682,7 +682,7 @@
 
 .bulk-send-item-email {
     font-size: 0.85rem;
-    color: var(--gray-500);
+    color: var(--black);
 }
 
 .bulk-send-item-subject {
@@ -693,7 +693,7 @@
 
 .bulk-send-item-body {
     font-size: 0.85rem;
-    color: var(--gray-600);
+    color: var(--black);
     white-space: pre-line;
     line-height: 1.5;
     max-height: 120px;
@@ -733,11 +733,11 @@
 }
 
 [data-theme="dark"] .stat-value {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .data-table th {
-    color: var(--gray-400);
+    color: var(--white);
     border-bottom-color: var(--gray-700);
 }
 
@@ -753,13 +753,13 @@
 [data-theme="dark"] .filter-group input {
     background: var(--gray-900);
     border-color: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
     color-scheme: dark;
 }
 
 [data-theme="dark"] .form-group label,
 [data-theme="dark"] .filter-group label {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 [data-theme="dark"] .modal-content {
@@ -771,15 +771,15 @@
 }
 
 [data-theme="dark"] .modal-header h3 {
-    color: var(--gray-100);
+    color: var(--white);
 }
 
 [data-theme="dark"] .modal-close {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 [data-theme="dark"] .modal-close:hover {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .modal-footer {
@@ -787,7 +787,7 @@
 }
 
 [data-theme="dark"] .bulk-send-status {
-    color: var(--gray-400);
+    color: var(--white);
     border-bottom-color: var(--gray-700);
 }
 
@@ -796,11 +796,11 @@
 }
 
 [data-theme="dark"] .bulk-send-item-email {
-    color: var(--gray-500);
+    color: var(--white);
 }
 
 [data-theme="dark"] .bulk-send-item-body {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 [data-theme="dark"] .bulk-send-list::-webkit-scrollbar,
@@ -829,11 +829,11 @@
 }
 
 [data-theme="dark"] .tab {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 [data-theme="dark"] .tab:hover {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .draft-status-bar {
@@ -869,7 +869,7 @@
 }
 
 [data-theme="dark"] .gray-border {
-    color: var(--gray-500);
+    color: var(--white);
 }
 
 [data-theme="dark"] .leads-table-wrapper::-webkit-scrollbar,
@@ -919,7 +919,7 @@
 
 .hint {
     font-size: 13px;
-    color: var(--gray-500);
+    color: var(--black);
     margin: 12px 0;
 }
 
@@ -945,7 +945,7 @@
     align-items: center;
     margin-bottom: 8px;
     font-size: 13px;
-    color: var(--gray-700);
+    color: var(--black);
 }
 
 .variant-row-header label {
@@ -958,13 +958,13 @@
 /* Neutral (no-color-modifier) button used inside the A/B create form. */
 .btn-neutral {
     background: var(--white);
-    color: var(--gray-700);
+    color: var(--black);
     border: 1px solid var(--gray-border);
 }
 
 .btn-neutral:hover {
     background: var(--gray-100, #f3f4f6);
-    color: var(--gray-800);
+    color: var(--black);
 }
 
 .variant-remove {
@@ -986,7 +986,7 @@
     word-break: break-word;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 13px;
-    color: var(--gray-700);
+    color: var(--black);
 }
 
 /* Status pills (test status) */
@@ -1003,7 +1003,7 @@
 
 .status-draft {
     background: var(--gray-100, #f3f4f6);
-    color: var(--gray-700);
+    color: var(--black);
 }
 
 .status-active {
@@ -1033,7 +1033,7 @@
 
 .conf-insufficient {
     background: var(--gray-100, #f3f4f6);
-    color: var(--gray-500, #6b7280);
+    color: var(--black);
 }
 
 .conf-trending {
@@ -1074,7 +1074,7 @@
     margin: 0 0 12px 0;
     font-size: 14px;
     font-weight: 600;
-    color: var(--gray-700);
+    color: var(--black);
 }
 
 .chart-wrap {
@@ -1099,14 +1099,14 @@
 .meta-label {
     font-size: 11px;
     text-transform: uppercase;
-    color: var(--gray-500);
+    color: var(--black);
     font-weight: 600;
     letter-spacing: 0.04em;
 }
 
 .meta-value {
     font-size: 14px;
-    color: var(--gray-800);
+    color: var(--black);
     font-weight: 500;
     margin-top: 2px;
     word-break: break-word;
@@ -1136,7 +1136,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--gray-700);
+    color: var(--black);
 }
 
 .segmented-option:hover {
@@ -1146,7 +1146,7 @@
 .segmented-option.active {
     border-color: var(--primary-blue);
     background: rgba(59, 130, 246, 0.08);
-    color: var(--gray-800);
+    color: var(--black);
 }
 
 .segmented-title {
@@ -1156,14 +1156,14 @@
 
 .segmented-desc {
     font-size: 12px;
-    color: var(--gray-500);
+    color: var(--black);
     line-height: 1.4;
 }
 
 /* Log tail in Settings tab */
 .log-tail {
     background: var(--gray-900, #0f172a);
-    color: #e2e8f0;
+    color: var(--white);
     padding: 12px 14px;
     border-radius: 6px;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -1180,16 +1180,16 @@
 [data-theme="dark"] .variant-row {
     background: var(--gray-900);
     border-color: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .variant-row-header {
-    color: var(--gray-300);
+    color: var(--white);
 }
 
 [data-theme="dark"] .variant-content-cell,
 [data-theme="dark"] .hint code {
-    color: var(--gray-300);
+    color: var(--white);
     background: var(--gray-900);
 }
 
@@ -1198,11 +1198,11 @@
 }
 
 [data-theme="dark"] .meta-label {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 [data-theme="dark"] .meta-value {
-    color: var(--gray-100);
+    color: var(--white);
 }
 
 [data-theme="dark"] .chart-card {
@@ -1211,17 +1211,17 @@
 }
 
 [data-theme="dark"] .chart-card h3 {
-    color: var(--gray-300);
+    color: var(--white);
 }
 
 [data-theme="dark"] .status-draft {
     background: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .conf-insufficient {
     background: var(--gray-700);
-    color: var(--gray-300);
+    color: var(--white);
 }
 
 [data-theme="dark"] .directive-pill {
@@ -1232,7 +1232,7 @@
 [data-theme="dark"] .segmented-option {
     background: var(--gray-800);
     border-color: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .segmented-option:hover {
@@ -1242,26 +1242,26 @@
 [data-theme="dark"] .segmented-option.active {
     background: rgba(59, 130, 246, 0.18);
     border-color: var(--primary-blue);
-    color: var(--gray-100);
+    color: var(--white);
 }
 
 [data-theme="dark"] .segmented-desc {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 [data-theme="dark"] .hint {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 [data-theme="dark"] .btn-neutral {
     background: var(--gray-800);
-    color: var(--gray-200);
+    color: var(--white);
     border-color: var(--gray-700);
 }
 
 [data-theme="dark"] .btn-neutral:hover {
     background: var(--gray-700);
-    color: var(--gray-100);
+    color: var(--white);
 }
 
 [data-theme="dark"] .variant-remove:hover {
@@ -1287,14 +1287,14 @@
     padding: 10px 20px;
     font-size: 15px;
     font-weight: 600;
-    color: var(--gray-500);
+    color: var(--black);
     cursor: pointer;
     border-bottom: 3px solid transparent;
     margin-bottom: -2px;
     transition: color 0.15s, border-color 0.15s;
 }
 
-.channel-tab:hover { color: var(--gray-700); }
+.channel-tab:hover { color: var(--black); }
 
 .channel-tab.active {
     color: var(--blue-700);
@@ -1305,8 +1305,8 @@
 .channel-pane.active { display: block; }
 
 [data-theme="dark"] .channel-tabs { border-bottom-color: var(--gray-700); }
-[data-theme="dark"] .channel-tab { color: var(--gray-400); }
-[data-theme="dark"] .channel-tab:hover { color: var(--gray-200); }
+[data-theme="dark"] .channel-tab { color: var(--white); }
+[data-theme="dark"] .channel-tab:hover { color: var(--white); }
 [data-theme="dark"] .channel-tab.active { color: var(--blue-400, #60a5fa); border-bottom-color: var(--blue-400, #60a5fa); }
 
 /* ─── Generic color badges (used by Reddit + future channels) ─────────── */
@@ -1315,13 +1315,13 @@
 .badge-red { background: var(--red-100); color: var(--red-700); }
 .badge-yellow { background: var(--amber-100); color: var(--amber-700); }
 .badge-blue { background: var(--blue-100); color: var(--blue-700); }
-.badge-gray { background: var(--gray-100); color: var(--gray-700); }
+.badge-gray { background: var(--gray-100); color: var(--black); }
 
 [data-theme="dark"] .badge-green { background: rgba(34,197,94,0.18); color: #86efac; }
 [data-theme="dark"] .badge-red { background: rgba(239,68,68,0.18); color: #fca5a5; }
 [data-theme="dark"] .badge-yellow { background: rgba(245,158,11,0.18); color: #fcd34d; }
 [data-theme="dark"] .badge-blue { background: rgba(59,130,246,0.18); color: #93c5fd; }
-[data-theme="dark"] .badge-gray { background: var(--gray-700); color: var(--gray-200); }
+[data-theme="dark"] .badge-gray { background: var(--gray-700); color: var(--white); }
 
 /* ─── Reddit progress banner ──────────────────────────────────────────── */
 
@@ -1330,7 +1330,7 @@
     align-items: center;
     gap: 12px;
     background: var(--blue-50, #eff6ff);
-    color: var(--gray-800);
+    color: var(--black);
     border: 1px solid var(--blue-200, #bfdbfe);
     border-left: 4px solid var(--primary-blue, #3b82f6);
     border-radius: 6px;
@@ -1345,7 +1345,7 @@
 }
 
 .reddit-progress-banner .reddit-progress-counts {
-    color: var(--gray-500);
+    color: var(--black);
     font-size: 12px;
     white-space: nowrap;
 }
@@ -1366,12 +1366,12 @@
 
 [data-theme="dark"] .reddit-progress-banner {
     background: var(--navy-1e3a5f, #1e3a5f);
-    color: var(--gray-100);
+    color: var(--white);
     border-color: var(--gray-700);
 }
 
 [data-theme="dark"] .reddit-progress-banner .reddit-progress-counts {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 [data-theme="dark"] .reddit-progress-banner.banner-success {
@@ -1396,29 +1396,29 @@
 [data-theme="dark"] #redditThreadModal .form-help,
 [data-theme="dark"] #redditMarkRepliedModal .text-muted,
 [data-theme="dark"] #redditMarkRepliedModal .form-help {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .safety-meter-label,
 [data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .stat-label {
-    color: var(--gray-300);
+    color: var(--white);
 }
 
 [data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .stat-value,
 [data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .safety-meter-value {
-    color: var(--gray-100);
+    color: var(--white);
 }
 
 [data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .reddit-thread-section h4 {
-    color: var(--gray-300);
+    color: var(--white);
 }
 
 [data-theme="dark"] #redditThreadModal .reddit-thread-section h4 {
-    color: var(--gray-300);
+    color: var(--white);
 }
 
 [data-theme="dark"] .channel-pane[data-channel-pane="reddit"] .reddit-diagnostics {
-    color: var(--gray-100);
+    color: var(--white);
 }
 
 /* ─── Reddit safety meter ─────────────────────────────────────────────── */
@@ -1444,7 +1444,7 @@
 
 .safety-meter-label {
     font-size: 12px;
-    color: var(--gray-600);
+    color: var(--black);
     margin-bottom: 4px;
 }
 
@@ -1455,7 +1455,7 @@
 }
 
 .safety-meter-divider {
-    color: var(--gray-400);
+    color: var(--black);
     margin: 0 4px;
 }
 
@@ -1491,7 +1491,7 @@
     height: 22px;
     border-radius: 999px;
     background: var(--gray-200);
-    color: var(--gray-700);
+    color: var(--black);
     font-size: 13px;
     font-weight: 700;
     line-height: 1;
@@ -1512,7 +1512,7 @@
     max-width: 320px;
     padding: 10px 12px;
     background: #1f2937;
-    color: #f9fafb;
+    color: var(--white);
     border-radius: 6px;
     font-size: 12px;
     font-weight: 400;
@@ -1547,7 +1547,7 @@
 
 [data-theme="dark"] .reddit-safety-meter { background: var(--gray-800); border-color: var(--gray-700); }
 [data-theme="dark"] .safety-meter-bar { background: var(--gray-700); }
-[data-theme="dark"] .safety-meter-help-icon { background: var(--gray-700); color: var(--gray-200); }
+[data-theme="dark"] .safety-meter-help-icon { background: var(--gray-700); color: var(--white); }
 [data-theme="dark"] .safety-meter-help:hover .safety-meter-help-icon,
 [data-theme="dark"] .safety-meter-help:focus-visible .safety-meter-help-icon { background: var(--primary-blue); color: #fff; }
 [data-theme="dark"] .safety-meter-help-tooltip { background: #0f172a; box-shadow: 0 6px 16px rgba(0, 0, 0, 0.5); }
@@ -1582,13 +1582,13 @@
 
 .reddit-ai-high { background: var(--green-100); color: var(--green-700); }
 .reddit-ai-mid { background: var(--amber-100); color: var(--amber-700); }
-.reddit-ai-low { background: var(--gray-100); color: var(--gray-600); }
+.reddit-ai-low { background: var(--gray-100); color: var(--black); }
 
 [data-theme="dark"] .reddit-table-wrapper { background: var(--gray-800); border-color: var(--gray-700); }
 [data-theme="dark"] .reddit-table tr:hover { background: var(--gray-700); }
 [data-theme="dark"] .reddit-ai-high { background: rgba(34,197,94,0.18); color: #86efac; }
 [data-theme="dark"] .reddit-ai-mid { background: rgba(245,158,11,0.18); color: #fcd34d; }
-[data-theme="dark"] .reddit-ai-low { background: var(--gray-700); color: var(--gray-300); }
+[data-theme="dark"] .reddit-ai-low { background: var(--gray-700); color: var(--white); }
 
 /* ─── Reddit thread detail modal ──────────────────────────────────────── */
 
@@ -1608,7 +1608,7 @@
 .reddit-thread-meta a:hover { text-decoration: underline; }
 
 .reddit-thread-section { margin-bottom: 16px; }
-.reddit-thread-section h4 { margin: 0 0 6px; font-size: 13px; color: var(--gray-600); font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; }
+.reddit-thread-section h4 { margin: 0 0 6px; font-size: 13px; color: var(--black); font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; }
 
 .reddit-thread-body {
     background: var(--gray-50, #f9fafb);
@@ -1654,7 +1654,7 @@
     margin-bottom: 6px;
     font-size: 13px;
     font-weight: 500;
-    color: var(--gray-700);
+    color: var(--black);
 }
 
 .reddit-regenerate-feedback textarea {
@@ -1681,13 +1681,13 @@
 }
 
 [data-theme="dark"] .reddit-regenerate-feedback label {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .reddit-regenerate-feedback textarea {
     background: var(--gray-800);
     border-color: var(--gray-700);
-    color: var(--gray-100);
+    color: var(--white);
 }
 
 [data-theme="dark"] .reddit-thread-meta { border-bottom-color: var(--gray-700); }
@@ -1695,8 +1695,8 @@
 [data-theme="dark"] .channel-pane[data-channel-pane="reddit"] a:not(.btn):not(.channel-tab):not(.section-tab),
 [data-theme="dark"] #redditThreadModal a:not(.btn),
 [data-theme="dark"] #redditMarkRepliedModal a:not(.btn) { color: var(--blue-400); }
-[data-theme="dark"] .reddit-thread-body { background: var(--gray-900, #111827); border-color: var(--gray-700); color: var(--gray-200); }
-[data-theme="dark"] #redditDraftBody { background: var(--gray-900, #111827); border-color: var(--gray-700); color: var(--gray-200); }
+[data-theme="dark"] .reddit-thread-body { background: var(--gray-900, #111827); border-color: var(--gray-700); color: var(--white); }
+[data-theme="dark"] #redditDraftBody { background: var(--gray-900, #111827); border-color: var(--gray-700); color: var(--white); }
 
 .checkbox-label {
     display: flex;
@@ -1765,7 +1765,7 @@
 .form-help {
     margin: 4px 0 0;
     font-size: 12px;
-    color: var(--gray-500);
+    color: var(--black);
 }
 
 .reddit-diagnostics {
@@ -1788,7 +1788,7 @@
 
 [data-theme="dark"] .reddit-settings-panel { background: var(--gray-800); border-color: var(--gray-700); }
 [data-theme="dark"] .reddit-settings-panel .panel-header { background: var(--gray-900, #111827); border-bottom-color: var(--gray-700); }
-[data-theme="dark"] .reddit-add-form input[type="text"] { background: var(--gray-900, #111827); border-color: var(--gray-700); color: var(--gray-100); }
+[data-theme="dark"] .reddit-add-form input[type="text"] { background: var(--gray-900, #111827); border-color: var(--gray-700); color: var(--white); }
 [data-theme="dark"] .reddit-diagnostics-error { background: rgba(239,68,68,0.15); color: #fca5a5; }
 
 /* ─── Flash messages (for reddit-settings POST-back) ──────────────────── */

--- a/admin/payments/index.php
+++ b/admin/payments/index.php
@@ -526,7 +526,7 @@ include __DIR__ . '/../admin_header.php';
                 <h2>Recent Payments</h2>
             </div>
             <?php if (empty($recent_payments)): ?>
-                <p style="text-align: center; color: #6b7280; padding: 2rem;">No payments recorded yet</p>
+                <p style="text-align: center; color: var(--black); padding: 2rem;">No payments recorded yet</p>
             <?php else: ?>
                 <div class="table-responsive">
                     <table>
@@ -608,7 +608,7 @@ include __DIR__ . '/../admin_header.php';
                 <span class="result-count"><?php echo count($transactions); ?> results</span>
             </div>
             <?php if (empty($transactions)): ?>
-                <p style="text-align: center; color: #6b7280; padding: 2rem;">No transactions found</p>
+                <p style="text-align: center; color: var(--black); padding: 2rem;">No transactions found</p>
             <?php else: ?>
                 <div class="table-responsive">
                     <table data-paginate="25">
@@ -664,7 +664,7 @@ include __DIR__ . '/../admin_header.php';
                 <span class="result-count"><?php echo count($companies); ?> companies</span>
             </div>
             <?php if (empty($companies)): ?>
-                <p style="text-align: center; color: #6b7280; padding: 2rem;">No companies registered yet</p>
+                <p style="text-align: center; color: var(--black); padding: 2rem;">No companies registered yet</p>
             <?php else: ?>
                 <div class="table-responsive">
                     <table>
@@ -800,7 +800,7 @@ include __DIR__ . '/../admin_header.php';
                                                             if (!empty($company['locked'])) {
                                                                 echo '<strong style="color:#dc2626;">Locked</strong>';
                                                                 if (!empty($company['locked_at'])) echo ' on ' . date('M j', strtotime($company['locked_at']));
-                                                                if (!empty($company['lock_reason'])) echo '<br><small style="color:#6b7280;">' . htmlspecialchars($company['lock_reason']) . '</small>';
+                                                                if (!empty($company['lock_reason'])) echo '<br><small style="color:var(--black);">' . htmlspecialchars($company['lock_reason']) . '</small>';
                                                             } else {
                                                                 echo 'Active';
                                                             }
@@ -848,7 +848,7 @@ include __DIR__ . '/../admin_header.php';
                                                             <td><?php echo date('M j, Y g:i A', strtotime($ec['created_at'])); ?></td>
                                                             <td>
                                                                 <?php echo htmlspecialchars($ec['old_email']); ?>
-                                                                <span style="color:#6b7280;"> → </span>
+                                                                <span style="color:var(--black);"> → </span>
                                                                 <?php echo htmlspecialchars($ec['new_email']); ?>
                                                             </td>
                                                             <td>
@@ -931,7 +931,7 @@ include __DIR__ . '/../admin_header.php';
                 <span class="result-count"><?php echo count($invoices); ?> results</span>
             </div>
             <?php if (empty($invoices)): ?>
-                <p style="text-align: center; color: #6b7280; padding: 2rem;">No invoices found</p>
+                <p style="text-align: center; color: var(--black); padding: 2rem;">No invoices found</p>
             <?php else: ?>
                 <div class="table-responsive">
                     <table data-paginate="25">
@@ -1074,10 +1074,10 @@ include __DIR__ . '/../admin_header.php';
         <div class="table-container">
             <div class="table-header">
                 <h2>Refund Requests</h2>
-                <span class="subtext" style="color:#6b7280;font-size:.85rem;">In-flight orchestration. Completed refunds appear in "Refunded Payments" below.</span>
+                <span class="subtext" style="color:var(--black);font-size:.85rem;">In-flight orchestration. Completed refunds appear in "Refunded Payments" below.</span>
             </div>
             <?php if (empty($inflight_refunds)): ?>
-                <p style="text-align: center; color: #6b7280; padding: 1.5rem;">No in-flight refund requests.</p>
+                <p style="text-align: center; color: var(--black); padding: 1.5rem;">No in-flight refund requests.</p>
             <?php else: ?>
                 <div class="table-responsive">
                     <table data-paginate="25">
@@ -1122,7 +1122,7 @@ include __DIR__ . '/../admin_header.php';
                                             </form>
                                         <?php endif; ?>
                                         <?php if ($r['state_reason']): ?>
-                                            <small style="color:#6b7280;display:block;margin-top:2px;"><?php echo htmlspecialchars(substr($r['state_reason'], 0, 80)); ?></small>
+                                            <small style="color:var(--black);display:block;margin-top:2px;"><?php echo htmlspecialchars(substr($r['state_reason'], 0, 80)); ?></small>
                                         <?php endif; ?>
                                     </td>
                                 </tr>
@@ -1139,7 +1139,7 @@ include __DIR__ . '/../admin_header.php';
                 <h2>Failed Payments</h2>
             </div>
             <?php if (empty($failed_payments)): ?>
-                <p style="text-align: center; color: #6b7280; padding: 2rem;">No failed payments</p>
+                <p style="text-align: center; color: var(--black); padding: 2rem;">No failed payments</p>
             <?php else: ?>
                 <div class="table-responsive">
                     <table data-paginate="25">
@@ -1176,7 +1176,7 @@ include __DIR__ . '/../admin_header.php';
                 <h2>Refunded Payments</h2>
             </div>
             <?php if (empty($refunded_payments)): ?>
-                <p style="text-align: center; color: #6b7280; padding: 2rem;">No refunded payments</p>
+                <p style="text-align: center; color: var(--black); padding: 2rem;">No refunded payments</p>
             <?php else: ?>
                 <div class="table-responsive">
                     <table data-paginate="25">

--- a/admin/payments/style.css
+++ b/admin/payments/style.css
@@ -271,7 +271,7 @@
 
 .provider-badge.disconnected {
     background-color: var(--gray-bg-light);
-    color: var(--gray-placeholder);
+    color: var(--black);
 }
 
 /* ============================================================
@@ -293,7 +293,7 @@
 .expand-arrow {
     display: inline-block;
     transition: transform 0.2s ease;
-    color: var(--gray-placeholder);
+    color: var(--black);
     font-size: 0.875rem;
 }
 

--- a/admin/referral-links/style.css
+++ b/admin/referral-links/style.css
@@ -36,7 +36,7 @@
 
 .stat-card .subtext {
     font-size: 14px;
-    color: var(--gray-placeholder);
+    color: var(--black);
 }
 
 .period-selection {
@@ -281,7 +281,7 @@ code {
 }
 
 .modal-close {
-    color: var(--gray-placeholder);
+    color: var(--black);
     float: right;
     font-size: 32px;
     font-weight: bold;
@@ -364,7 +364,7 @@ code {
 
 [data-theme="dark"] .chart-container h2,
 [data-theme="dark"] .table-header-actions h2 {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 /* ─── Group-by toggle (source vs category) ────────────────────────────── */
@@ -428,7 +428,7 @@ code {
 .cat-caret {
     display: inline-block;
     margin-right: 8px;
-    color: var(--gray-500);
+    color: var(--black);
     transition: transform 0.15s;
 }
 
@@ -443,7 +443,7 @@ code {
 
 .cat-meta {
     margin-left: 10px;
-    color: var(--gray-500);
+    color: var(--black);
     font-weight: 500;
 }
 
@@ -456,12 +456,12 @@ code {
 }
 
 [data-theme="dark"] .group-toggle > span {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .group-btn {
     background: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .group-btn:hover {
@@ -482,10 +482,10 @@ code {
 }
 
 [data-theme="dark"] .cat-name {
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .cat-meta {
-    color: var(--gray-400);
+    color: var(--white);
 }
 

--- a/admin/reports/style.css
+++ b/admin/reports/style.css
@@ -18,7 +18,7 @@
 
 .filter-group label {
   font-size: 14px;
-  color: var(--gray-700);
+  color: var(--black);
 }
 
 .filter-group select {
@@ -48,7 +48,7 @@
 
 .status-badge-label {
   font-size: 13px;
-  color: var(--gray-500);
+  color: var(--black);
   text-transform: uppercase;
   font-weight: 500;
 }
@@ -56,7 +56,7 @@
 .status-badge-count {
   font-size: 24px;
   font-weight: 700;
-  color: var(--gray-800);
+  color: var(--black);
   text-align: center;
 }
 
@@ -101,7 +101,7 @@
 
 .report-id {
   font-size: 11px;
-  color: var(--gray-400);
+  color: var(--black);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -110,7 +110,7 @@
 .report-title {
   font-size: 15px;
   font-weight: 600;
-  color: var(--gray-800);
+  color: var(--black);
   margin: 2px 0 0 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -129,13 +129,13 @@
   display: flex;
   gap: 8px;
   font-size: 12px;
-  color: var(--gray-500);
+  color: var(--black);
   align-items: center;
   flex-wrap: wrap;
 }
 
 .meta-separator {
-  color: var(--gray-input-border);
+  color: var(--black);
   font-weight: 300;
 }
 
@@ -146,7 +146,7 @@
   margin: 10px 0 8px 0;
   font-size: 13px;
   line-height: 1.5;
-  color: var(--gray-600);
+  color: var(--black);
   max-height: 80px;
   overflow: hidden;
   position: relative;
@@ -165,7 +165,7 @@
 
 .report-details {
   font-size: 13px;
-  color: var(--gray-500);
+  color: var(--black);
   margin: 8px 0;
   padding: 8px 12px;
   background: var(--amber-50);
@@ -206,7 +206,7 @@
 
 .status-badge-inline.dismissed {
   background: var(--gray-100);
-  color: var(--gray-700);
+  color: var(--black);
   border: 1px solid var(--gray-border);
 }
 
@@ -308,7 +308,7 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  color: var(--gray-500);
+  color: var(--black);
 }
 
 .empty-state svg {
@@ -358,14 +358,14 @@
   border: none;
   font-size: 28px;
   cursor: pointer;
-  color: var(--gray-500);
+  color: var(--black);
   padding: 0;
   width: 32px;
   height: 32px;
 }
 
 .modal-close:hover {
-  color: var(--gray-800);
+  color: var(--black);
 }
 
 .modal-body {
@@ -377,7 +377,7 @@
 }
 
 .modal-body .form-group label {
-  color: var(--gray-700);
+  color: var(--black);
 }
 
 .modal-body .form-group textarea,

--- a/admin/reviews/style.css
+++ b/admin/reviews/style.css
@@ -31,7 +31,7 @@
 }
 
 .review-section h2 .count {
-    color: var(--gray-600, #6b7280);
+    color: var(--black);
     font-weight: 400;
     font-size: 14px;
 }
@@ -46,12 +46,12 @@
 
 .section-description {
     font-size: 13px;
-    color: var(--gray-600, #6b7280);
+    color: var(--black);
     margin: 0 0 14px 0;
 }
 
 .empty-state {
-    color: var(--gray-500, #9ca3af);
+    color: var(--black);
     font-style: italic;
     margin: 0;
 }
@@ -72,7 +72,7 @@
 .reviews-table th {
     font-weight: 600;
     background: var(--gray-50, #f9fafb);
-    color: var(--gray-700, #374151);
+    color: var(--black);
     font-size: 12px;
     text-transform: uppercase;
     letter-spacing: 0.4px;
@@ -105,19 +105,19 @@
    light-on-dark without this. */
 [data-theme="dark"] .btn-gray {
     background-color: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
     border-color: var(--black);
 }
 
 [data-theme="dark"] .btn-gray:hover {
     background-color: var(--gray-600);
-    color: var(--gray-100);
+    color: var(--white);
 }
 
 [data-theme="dark"] .reviews-intro {
     background: var(--blue-alpha-15);
     border-left-color: var(--blue-400);
-    color: var(--gray-300);
+    color: var(--white);
 }
 
 [data-theme="dark"] .review-section {
@@ -140,21 +140,21 @@
 [data-theme="dark"] .review-section h2 .count,
 [data-theme="dark"] .section-description,
 [data-theme="dark"] .empty-state {
-    color: var(--gray-400);
+    color: var(--white);
 }
 
 [data-theme="dark"] .reviews-table th,
 [data-theme="dark"] .reviews-table td {
     border-bottom-color: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
 }
 
 [data-theme="dark"] .reviews-table th {
     background: var(--gray-700);
-    color: var(--gray-300);
+    color: var(--white);
 }
 
 [data-theme="dark"] .reviews-table code {
     background: var(--gray-700);
-    color: var(--gray-200);
+    color: var(--white);
 }

--- a/admin/search.css
+++ b/admin/search.css
@@ -6,7 +6,7 @@
 .filter-group label {
     font-size: 14px;
     font-weight: 600;
-    color: var(--gray-700);
+    color: var(--black);
     margin-bottom: 6px;
 }
 
@@ -54,7 +54,7 @@
 
 .selection-info {
     font-weight: 500;
-    color: var(--gray-700);
+    color: var(--black);
     margin-right: 20px;
 }
 

--- a/admin/style.css
+++ b/admin/style.css
@@ -24,7 +24,7 @@
 .summary-card-label {
   font-size: 0.8rem;
   font-weight: 500;
-  color: var(--gray-500);
+  color: var(--black);
   text-transform: uppercase;
   letter-spacing: 0.03em;
   margin-bottom: 0.25rem;
@@ -33,7 +33,7 @@
 .summary-card-value {
   font-size: 1.75rem;
   font-weight: 700;
-  color: var(--gray-800);
+  color: var(--black);
 }
 
 /* Hero Section */
@@ -45,7 +45,7 @@
 .hero-section h1 {
   font-size: 2rem;
   font-weight: 700;
-  color: var(--gray-800);
+  color: var(--black);
   margin-bottom: 0.5rem;
   letter-spacing: -0.02em;
 }
@@ -71,7 +71,7 @@
 .chart-card-title {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--gray-800);
+  color: var(--black);
   margin: 0 0 1rem 0;
 }
 
@@ -88,15 +88,15 @@
 }
 
 [data-theme="dark"] .summary-card-label {
-  color: var(--gray-400);
+  color: var(--white);
 }
 
 [data-theme="dark"] .summary-card-value {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 [data-theme="dark"] .hero-section h1 {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 [data-theme="dark"] .chart-card {
@@ -106,7 +106,7 @@
 }
 
 [data-theme="dark"] .chart-card-title {
-  color: var(--gray-100);
+  color: var(--white);
 }
 
 /* Responsive */

--- a/admin/users/style.css
+++ b/admin/users/style.css
@@ -11,7 +11,7 @@
 .stat-card h3 {
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--gray-500);
+  color: var(--black);
   margin: 0 0 0.5rem 0;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -20,7 +20,7 @@
 .stat-value {
   font-size: 2rem;
   font-weight: 700;
-  color: var(--gray-800);
+  color: var(--black);
   line-height: 1;
 }
 
@@ -46,7 +46,7 @@
   margin: 0;
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--gray-800);
+  color: var(--black);
 }
 
 /* Search Form */
@@ -107,7 +107,7 @@
 .clear-button {
   padding: 0.5rem 1rem;
   background: var(--gray-100);
-  color: var(--gray-500);
+  color: var(--black);
   text-decoration: none;
   border-radius: 6px;
   font-size: 0.875rem;
@@ -121,7 +121,7 @@
 
 .clear-button:hover {
   background: var(--gray-border);
-  color: var(--gray-700);
+  color: var(--black);
 }
 
 /* Filter Groups (inline with search) */
@@ -134,7 +134,7 @@
 .filter-group label {
   font-size: 0.75rem;
   font-weight: 500;
-  color: var(--gray-500);
+  color: var(--black);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -163,7 +163,7 @@
 [data-theme="dark"] .filter-group input[type="date"] {
   background: var(--gray-700);
   border-color: var(--black);
-  color: var(--gray-200);
+  color: var(--white);
 }
 
 [data-theme="dark"] .filter-group input[type="date"]::-webkit-calendar-picker-indicator {
@@ -209,7 +209,7 @@
 
 .selection-info {
   font-size: 0.875rem;
-  color: var(--gray-500);
+  color: var(--black);
   font-weight: 500;
 }
 
@@ -269,7 +269,7 @@
 .no-results {
   padding: 3rem 2rem;
   text-align: center;
-  color: var(--gray-500);
+  color: var(--black);
 }
 
 .no-results svg {


### PR DESCRIPTION
- Replace gray text colors across all admin pages with black (light theme) / white (dark theme) for readability
- Spell out "Monthly Active Users" on the app-stats Active Users tab
- Remove the Data Summary / Latest-Oldest Data line from app-stats