### PR TITLE
Bias outreach discovery toward new businesses

### DIFF
--- a/admin/outreach/tabs/settings.php
+++ b/admin/outreach/tabs/settings.php
@@ -114,6 +114,26 @@ function settings_tab_handle_post($pdo)
         header('Location: index.php?tab=settings'); exit;
     }
 
+    if ($action === 'set_max_review_count') {
+        $raw = trim((string) ($_POST['max_review_count'] ?? ''));
+        // Blank or 0 means "use the env/default fallback": clear the override.
+        if ($raw === '' || $raw === '0') {
+            settings_tab_set_state($pdo, 'max_review_count', '');
+            $_SESSION['message'] = 'Review-count ceiling reset to the default.';
+            $_SESSION['message_type'] = 'success';
+            header('Location: index.php?tab=settings'); exit;
+        }
+        if (!ctype_digit($raw) || (int) $raw < 1 || (int) $raw > 2000) {
+            $_SESSION['message'] = 'Review-count ceiling must be a whole number between 1 and 2000 (or blank to use the default).';
+            $_SESSION['message_type'] = 'error';
+            header('Location: index.php?tab=settings'); exit;
+        }
+        settings_tab_set_state($pdo, 'max_review_count', (string) (int) $raw);
+        $_SESSION['message'] = 'Review-count ceiling set to ' . (int) $raw . '.';
+        $_SESSION['message_type'] = 'success';
+        header('Location: index.php?tab=settings'); exit;
+    }
+
     header('Location: index.php?tab=settings'); exit;
 }
 
@@ -274,6 +294,51 @@ function settings_tab_render($pdo)
                     </button>
                 </form>
             </div>
+        </div>
+    </div>
+
+    <?php
+    // ─── Discovery filters panel ───
+    // Review-count ceiling: lower = skews discovery toward newer / smaller
+    // businesses (chains and long-established operators accrue lots of reviews).
+    $reviewStateRaw = trim((string) settings_tab_get_state($pdo, 'max_review_count', ''));
+    $reviewEnvRaw   = trim((string) ($_ENV['OUTREACH_MAX_REVIEW_COUNT'] ?? ''));
+    $reviewIsOverride = ($reviewStateRaw !== '' && ctype_digit($reviewStateRaw) && (int) $reviewStateRaw > 0);
+    if ($reviewIsOverride) {
+        $reviewEffective = (int) $reviewStateRaw;
+        $reviewSource = 'this Settings value';
+    } elseif (ctype_digit($reviewEnvRaw) && (int) $reviewEnvRaw > 0) {
+        $reviewEffective = (int) $reviewEnvRaw;
+        $reviewSource = 'OUTREACH_MAX_REVIEW_COUNT in .env';
+    } else {
+        $reviewEffective = 15;
+        $reviewSource = 'the built-in default';
+    }
+    ?>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h2>Discovery filters</h2>
+        </div>
+        <div class="panel-content">
+            <p class="hint" style="margin-top:0;">
+                The Google Places channel skips businesses with more Google reviews than this ceiling. A low number biases discovery toward newer, smaller businesses (chains and long-established shops pile up reviews and usually already run accounting software). Leave blank to use <?php echo htmlspecialchars($reviewSource === 'OUTREACH_MAX_REVIEW_COUNT in .env' ? 'the .env value' : 'the default'); ?>.
+            </p>
+            <form method="POST" style="display:flex; gap:8px; align-items:flex-end; flex-wrap:wrap;">
+                <input type="hidden" name="tab" value="settings">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'] ?? ''); ?>">
+                <input type="hidden" name="action" value="set_max_review_count">
+                <div class="form-group" style="margin:0;">
+                    <label for="maxReviewCount">Max Google reviews (1-2000, blank = default)</label>
+                    <input type="number" id="maxReviewCount" name="max_review_count" min="1" max="2000"
+                           value="<?php echo $reviewIsOverride ? (int) $reviewStateRaw : ''; ?>"
+                           placeholder="<?php echo (int) $reviewEffective; ?>">
+                </div>
+                <button type="submit" class="btn btn-blue">Save</button>
+            </form>
+            <p class="hint" style="margin-bottom:0;">
+                Currently using <strong><?php echo (int) $reviewEffective; ?></strong> (from <?php echo htmlspecialchars($reviewSource); ?>).
+            </p>
         </div>
     </div>
 

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -1109,19 +1109,193 @@ function filter_category_type_mismatch($expectedType, $types)
 }
 
 /**
- * Soft signal: a Google business with hundreds of ratings is almost
- * certainly a national chain location (or a major tourist attraction).
- * Real Saskatoon plumbers/accountants/salons rarely exceed ~300 reviews.
+ * Soft signal: a Google business with lots of ratings is almost certainly an
+ * established operator (and a national chain location once it gets into the
+ * hundreds). A brand-new business still on spreadsheets, the kind Argo Books
+ * is trying to reach, has very few reviews. The default ceiling is deliberately
+ * low (15) to skew discovery toward newer businesses; callers that want the
+ * configured value should pass outreach_max_review_count().
  *
  * Returns true if review count exceeds threshold. NULL or 0 reviews are
  * treated as "no signal" and pass through.
  */
-function filter_review_count_too_high($reviewCount, $threshold = 300)
+function filter_review_count_too_high($reviewCount, $threshold = 15)
 {
     if ($reviewCount === null || $reviewCount === '') return false;
     $n = (int) $reviewCount;
     if ($n <= 0) return false;
     return $n > $threshold;
+}
+
+/**
+ * Resolve the configured max-review-count ceiling for discovery. Precedence:
+ *   1. DB state `max_review_count` in outreach_pipeline_state (Settings knob)
+ *   2. env OUTREACH_MAX_REVIEW_COUNT
+ *   3. hardcoded default (15)
+ *
+ * Uses the global $pdo defensively: if it's unavailable or the query fails
+ * (e.g. table missing on a fresh install), we silently fall back to env/default
+ * so discovery never breaks on a missing knob. Only positive integers count as
+ * a valid override; a blank/0/non-numeric state value means "use env/default".
+ */
+function outreach_max_review_count(): int
+{
+    $default = 15;
+
+    global $pdo;
+    if (isset($pdo)) {
+        try {
+            $stmt = $pdo->prepare("SELECT state_value FROM outreach_pipeline_state WHERE state_key = 'max_review_count'");
+            $stmt->execute();
+            $val = $stmt->fetchColumn();
+            if ($val !== false && is_numeric($val) && (int) $val > 0) {
+                return (int) $val;
+            }
+        } catch (PDOException $e) {
+            // Table missing or query failed: fall through to env/default.
+        }
+    }
+
+    $env = $_ENV['OUTREACH_MAX_REVIEW_COUNT'] ?? '';
+    if (is_numeric($env) && (int) $env > 0) {
+        return (int) $env;
+    }
+
+    return $default;
+}
+
+// ─── Newness / business-age detection ───
+
+/**
+ * Scan website HTML for an explicit business-founding year. Looks for
+ * copyright, "since YYYY", "established YYYY", "founded YYYY", and
+ * "YYYY-present" patterns and returns the OLDEST plausible founding year
+ * (1900..current year) found, or null if no signal is detected.
+ *
+ * Shared by the Shopify evaluator (business_too_old reject) and the Google
+ * Places newness gate. An established business that just refreshed its site
+ * still advertises its real age, which is exactly the "20-year-old shop that
+ * already has accounting software" we want to skip.
+ */
+function detect_storefront_founded_year(string $html): ?int
+{
+    // Decode entities so "&copy; 2006" footers match the © pattern below.
+    $text = html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $currentYear = (int) date('Y');
+    $oldestYear = null;
+
+    $patterns = [
+        '/©.{0,80}?(\d{4})/s',                                    // © 1995, © Acme Co 1995-2026
+        '/\bcopyright\b.{0,80}?(\d{4})/is',                       // copyright Acme Co 1995
+        '/\bsince\s+(\d{4})\b/i',                                 // since 1995
+        '/\b(?:est(?:ablished)?\.?)\s+(?:in\s+)?(\d{4})\b/i',     // est. 1995, established in 1995
+        '/\bfounded\s+(?:in\s+)?(\d{4})\b/i',                     // founded 1995, founded in 1995
+        '/\b(\d{4})\s*[-–—]\s*(?:present|today|now)\b/i',         // 1995-present
+    ];
+
+    foreach ($patterns as $pattern) {
+        if (preg_match_all($pattern, $text, $matches)) {
+            foreach ($matches[1] as $yearStr) {
+                $year = (int) $yearStr;
+                if ($year >= 1900 && $year <= $currentYear) {
+                    if ($oldestYear === null || $year < $oldestYear) {
+                        $oldestYear = $year;
+                    }
+                }
+            }
+        }
+    }
+
+    return $oldestYear;
+}
+
+/**
+ * Detect "this is an established business" signals from website HTML so the
+ * newness gate can skip operators that have clearly been around for years
+ * (and almost certainly already run accounting software). Pure / network-free.
+ *
+ * Returns:
+ *   [
+ *     'founded_year'     => int|null,   // oldest founding year detected
+ *     'years_experience' => int|null,   // largest "N years experience/in business" claim
+ *     'phrase'           => string|null // short snippet of the matched claim (for the log/reason)
+ *   ]
+ *
+ * Examples it catches: "serving the community since 1998", "© 2003",
+ * "20+ years experience", "over 25 years in business", "30 years of experience".
+ * Sparse / new / "now open" / "launching" sites match nothing and return all
+ * nulls, so they pass through.
+ */
+function detect_established_signals(string $html): array
+{
+    $foundedYear = detect_storefront_founded_year($html);
+
+    $text = html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $yearsExperience = null;
+    $phrase = null;
+
+    // "20+ years", "over 25 years", "more than 30 years", "25 years of experience",
+    // "20 years in business". Require the word "year(s)" plus an experience/business
+    // qualifier nearby so we don't match unrelated "N years" copy.
+    $expPatterns = [
+        '/\b(?:over|more than|nearly|almost)?\s*(\d{1,2})\s*\+?\s*years?\s+(?:of\s+)?(?:experience|expertise|in\s+business|serving|in\s+the\s+industry|of\s+service)\b/i',
+        '/\b(?:experience|expertise|in\s+business|serving|in\s+the\s+industry)\s+(?:for\s+)?(?:over|more than)?\s*(\d{1,2})\s*\+?\s*years?\b/i',
+    ];
+    foreach ($expPatterns as $pattern) {
+        if (preg_match_all($pattern, $text, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $m) {
+                $n = (int) $m[1];
+                if ($n >= 1 && $n <= 99 && ($yearsExperience === null || $n > $yearsExperience)) {
+                    $yearsExperience = $n;
+                    $phrase = trim(preg_replace('/\s+/', ' ', $m[0]));
+                    if (strlen($phrase) > 120) $phrase = substr($phrase, 0, 120);
+                }
+            }
+        }
+    }
+
+    return [
+        'founded_year'     => $foundedYear,
+        'years_experience' => $yearsExperience,
+        'phrase'           => $phrase,
+    ];
+}
+
+/**
+ * Fetch a website and return both the raw HTML and a cleaned, capped text
+ * version. Extracted from summarize_business() so a single fetch can feed
+ * both the newness check and the AI summary. Returns null on fetch failure
+ * or when the page has too little readable text to be useful.
+ *
+ * @return array{html:string, text:string}|null
+ */
+function fetch_website_text($website): ?array
+{
+    if (empty($website)) return null;
+
+    $context = stream_context_create([
+        'http' => [
+            'timeout' => 5,
+            'user_agent' => 'Mozilla/5.0',
+            'follow_location' => true,
+            'max_redirects' => 3,
+        ],
+        'ssl' => ['verify_peer' => true, 'verify_peer_name' => true],
+    ]);
+
+    $html = @file_get_contents($website, false, $context);
+    if (!$html) return null;
+
+    // Strip scripts, styles, and tags to get readable text
+    $text = preg_replace('/<script[^>]*>.*?<\/script>/is', '', $html);
+    $text = preg_replace('/<style[^>]*>.*?<\/style>/is', '', $text);
+    $text = strip_tags($text);
+    $text = preg_replace('/\s+/', ' ', $text);
+    $text = trim(mb_substr($text, 0, 3000)); // Cap at 3000 chars
+
+    if (strlen($text) < 50) return null;
+
+    return ['html' => $html, 'text' => $text];
 }
 
 // ─── Layer 3: AI Size Gate ───
@@ -1216,6 +1390,83 @@ PROMPT;
     if (strlen($reason) > 240) $reason = substr($reason, 0, 240);
 
     return ['classification' => $cls, 'reason' => $reason];
+}
+
+/**
+ * Ask Gemini whether a business looks NEW/early vs ESTABLISHED, based on its
+ * website text. This is the AI half of the newness gate: the cheap regex in
+ * detect_established_signals() catches explicit "since 1998 / 20+ years" copy;
+ * this catches softer signals (long client lists, decades of awards, "trusted
+ * for generations", a mature product catalogue) that have no literal year.
+ *
+ * Returns one of:
+ *   ['maturity' => 'new',         'reason' => '...']
+ *   ['maturity' => 'established', 'reason' => '...']
+ *   ['maturity' => 'unknown',     'reason' => '...']
+ *   ['error' => 'message']                              (API or parse failure)
+ *
+ * On 'error' or 'unknown', callers should pass-through (do NOT reject): the
+ * goal is to skew newer, not to block legitimate outreach on a Gemini hiccup.
+ */
+function classify_business_maturity_with_ai($businessName, $websiteText)
+{
+    $name = trim((string) $businessName);
+    $text = trim((string) $websiteText);
+    if ($text === '') {
+        return ['error' => 'missing website text'];
+    }
+    if (strlen($text) > 3000) {
+        $text = substr($text, 0, 3000);
+    }
+
+    $systemPrompt = <<<PROMPT
+You are screening outreach leads for Argo Books, simple bookkeeping software
+aimed at NEW and early-stage small businesses that likely haven't settled on
+accounting software yet. We want to SKIP businesses that are clearly long
+established (they almost always already run QuickBooks/Xero/Sage).
+
+Read the website text and judge how mature the business is:
+
+  "new"         — recently launched, "now open", "coming soon", sparse site,
+                  one or two offerings, no history, no long client roster.
+  "established" — clearly been operating for many years: talks about decades
+                  of service, "trusted since", generations, long awards history,
+                  hundreds of past projects/clients, a deep product catalogue.
+  "unknown"     — genuinely can't tell from the text.
+
+When torn between "new" and "unknown", prefer "unknown". Only answer
+"established" when the text gives clear evidence of long operation.
+
+Respond with ONLY a JSON object, no preamble:
+{"maturity": "new" | "established" | "unknown", "reason": "one short sentence"}
+PROMPT;
+
+    $details = $name !== '' ? "Business name: {$name}\n\nWebsite text:\n{$text}" : "Website text:\n{$text}";
+
+    $result = call_gemini($systemPrompt, $details);
+    if (isset($result['error'])) {
+        return ['error' => $result['error']];
+    }
+
+    $content = trim((string) ($result['content'] ?? ''));
+    $content = preg_replace('/^```json\s*/i', '', $content);
+    $content = preg_replace('/\s*```$/', '', $content);
+
+    $parsed = json_decode($content, true);
+    if (!is_array($parsed) || !isset($parsed['maturity'])) {
+        return ['error' => 'AI returned non-JSON or missing maturity field'];
+    }
+
+    $maturity = strtolower(trim((string) $parsed['maturity']));
+    if (!in_array($maturity, ['new', 'established', 'unknown'], true)) {
+        return ['error' => 'AI returned unknown maturity value: ' . $maturity];
+    }
+
+    $reason = trim((string) ($parsed['reason'] ?? ''));
+    if ($reason === '') $reason = '(no reason given)';
+    if (strlen($reason) > 240) $reason = substr($reason, 0, 240);
+
+    return ['maturity' => $maturity, 'reason' => $reason];
 }
 
 /**
@@ -1463,6 +1714,11 @@ function search_businesses_core($city, $province, $category, $limit, $apiKey, $e
     }
     $roundsUsed = 0;
 
+    // Resolve the review-count ceiling once up front. It's a config lookup
+    // (DB state -> env -> default), so we must not re-run it per candidate
+    // inside the rounds/pages loop below.
+    $maxReviewCount = outreach_max_review_count();
+
     // Build query variations to search across multiple rounds
     $queries = [];
     if ($category) {
@@ -1630,8 +1886,10 @@ function search_businesses_core($city, $province, $category, $limit, $apiKey, $e
                     continue;
                 }
 
-                // (c) Review-count cap: real local SMBs almost never exceed 300.
-                if (filter_review_count_too_high($reviewCount)) {
+                // (c) Review-count cap: a low ceiling (configurable via the
+                //     Outreach → Settings knob / OUTREACH_MAX_REVIEW_COUNT) skews
+                //     discovery toward newer businesses with few reviews.
+                if (filter_review_count_too_high($reviewCount, $maxReviewCount)) {
                     _outreach_filter_log("Filter reject [review_count_too_high:{$reviewCount}]: '{$businessName}' ({$website})");
                     continue;
                 }
@@ -1770,29 +2028,18 @@ function call_gemini($systemPrompt, $userPrompt)
 
 // ─── Business Summarization ───
 
-function summarize_business($website)
+function summarize_business($website, $prefetchedText = null)
 {
-    if (empty($website)) return null;
-
-    $context = stream_context_create([
-        'http' => [
-            'timeout' => 5,
-            'user_agent' => 'Mozilla/5.0',
-            'follow_location' => true,
-            'max_redirects' => 3,
-        ],
-        'ssl' => ['verify_peer' => true, 'verify_peer_name' => true],
-    ]);
-
-    $html = @file_get_contents($website, false, $context);
-    if (!$html) return null;
-
-    // Strip scripts, styles, and tags to get readable text
-    $text = preg_replace('/<script[^>]*>.*?<\/script>/is', '', $html);
-    $text = preg_replace('/<style[^>]*>.*?<\/style>/is', '', $text);
-    $text = strip_tags($text);
-    $text = preg_replace('/\s+/', ' ', $text);
-    $text = trim(mb_substr($text, 0, 3000)); // Cap at 3000 chars
+    // Reuse already-fetched page text when the caller has it (the draft flow
+    // fetches once for the newness check), otherwise fetch now.
+    if ($prefetchedText !== null && trim((string) $prefetchedText) !== '') {
+        $text = trim((string) $prefetchedText);
+    } else {
+        if (empty($website)) return null;
+        $fetched = fetch_website_text($website);
+        if ($fetched === null) return null;
+        $text = $fetched['text'];
+    }
 
     if (strlen($text) < 50) return null;
 
@@ -1853,6 +2100,65 @@ function generate_draft_for_lead($pdo, $lead)
             ];
         }
         // classification === 'small_independent' falls through to drafting.
+    }
+
+    // ─── Newness gate ───
+    // Argo Books targets NEW / early businesses that likely haven't settled on
+    // accounting software yet. Skip auto-discovered leads whose own website
+    // shows clear "established" signals (old founding year, "20+ years
+    // experience", decades of service). Two layers: a free regex pass, then an
+    // AI judgment for softer signals. Both pass-through on failure so a fetch
+    // miss or Gemini hiccup never blocks legitimate outreach.
+    //
+    // We fetch the homepage once here and hand the text to summarize_business
+    // below, so this adds at most one HTTP GET (and only at first draft, when
+    // no business_summary is stored yet). On regenerate, the lead was already
+    // vetted, so we skip the re-check.
+    $prefetchedSiteText = null;
+    if ($isAutoLead && empty($lead['business_summary']) && !empty($lead['website'])) {
+        $fetched = fetch_website_text($lead['website']);
+        if ($fetched !== null) {
+            $prefetchedSiteText = $fetched['text'];
+
+            $maxAgeYears = (int) ($_ENV['OUTREACH_ESTABLISHED_MAX_AGE_YEARS'] ?? 8);
+            if ($maxAgeYears < 1) $maxAgeYears = 8;
+            $currentYear = (int) date('Y');
+
+            // Layer A: cheap regex on the page HTML.
+            $signals = detect_established_signals($fetched['html']);
+            $establishedDetail = null;
+            if ($signals['founded_year'] !== null && $signals['founded_year'] <= ($currentYear - $maxAgeYears)) {
+                $age = $currentYear - $signals['founded_year'];
+                $establishedDetail = "Website shows founding year {$signals['founded_year']} (~{$age} years old)";
+            } elseif ($signals['years_experience'] !== null && $signals['years_experience'] >= $maxAgeYears) {
+                $establishedDetail = "Website advertises " . $signals['years_experience'] . "+ years"
+                    . ($signals['phrase'] ? " (\"{$signals['phrase']}\")" : '');
+            }
+            if ($establishedDetail !== null) {
+                disqualify_lead($pdo, $id, 'established_business', 'Newness gate: ' . $establishedDetail);
+                return [
+                    'success' => true,
+                    'disqualified' => true,
+                    'reason' => 'established_business',
+                    'detail' => $establishedDetail,
+                ];
+            }
+
+            // Layer B: AI maturity judgment for softer signals with no literal year.
+            $maturity = classify_business_maturity_with_ai($lead['business_name'] ?? '', $prefetchedSiteText);
+            if (isset($maturity['error'])) {
+                log_activity($pdo, $id, 'newness_gate_skipped', 'AI maturity error, proceeding: ' . $maturity['error']);
+            } elseif ($maturity['maturity'] === 'established') {
+                disqualify_lead($pdo, $id, 'ai_established_business', 'AI newness gate: ' . $maturity['reason']);
+                return [
+                    'success' => true,
+                    'disqualified' => true,
+                    'reason' => 'ai_established_business',
+                    'detail' => $maturity['reason'],
+                ];
+            }
+            // 'new' / 'unknown' fall through to drafting.
+        }
     }
 
     // A/B variant lookup must happen before the summary block so a
@@ -1921,7 +2227,9 @@ function generate_draft_for_lead($pdo, $lead)
     if ($personalizationOff) {
         $summary = null;
     } elseif (empty($summary) && !empty($lead['website'])) {
-        $summary = summarize_business($lead['website']);
+        // Reuse the page text fetched by the newness gate above (if any) so we
+        // don't fetch the same homepage twice.
+        $summary = summarize_business($lead['website'], $prefetchedSiteText);
         if ($summary) {
             $stmt = $pdo->prepare("UPDATE outreach_leads SET business_summary = ? WHERE id = ?");
             $stmt->execute([$summary, $id]);

--- a/cron/lib/shopify_discovery.php
+++ b/cron/lib/shopify_discovery.php
@@ -333,48 +333,6 @@ function detect_accounting_tool(string $html): ?string
 }
 
 /**
- * Scan storefront HTML for an explicit business-founding year.
- *
- * Looks for copyright, "since YYYY", "established YYYY", "founded YYYY", and
- * "YYYY-present" patterns and returns the OLDEST plausible founding year
- * (1900..current year) found, or null if no signal is detected.
- *
- * Intended for the business_too_old reject path: a 30-year-old company that
- * just migrated to Shopify is not a startup, even if its oldest product is
- * less than 24 months old.
- */
-function detect_storefront_founded_year(string $html): ?int
-{
-    $text = strip_tags($html);
-    $currentYear = (int) date('Y');
-    $oldestYear = null;
-
-    $patterns = [
-        '/©.{0,80}?(\d{4})/s',                                    // © 1995, © Acme Co 1995-2026
-        '/\bcopyright\b.{0,80}?(\d{4})/is',                       // copyright Acme Co 1995
-        '/\bsince\s+(\d{4})\b/i',                                 // since 1995
-        '/\b(?:est(?:ablished)?\.?)\s+(?:in\s+)?(\d{4})\b/i',     // est. 1995, established in 1995
-        '/\bfounded\s+(?:in\s+)?(\d{4})\b/i',                     // founded 1995, founded in 1995
-        '/\b(\d{4})\s*[-–—]\s*(?:present|today|now)\b/i',         // 1995-present
-    ];
-
-    foreach ($patterns as $pattern) {
-        if (preg_match_all($pattern, $text, $matches)) {
-            foreach ($matches[1] as $yearStr) {
-                $year = (int) $yearStr;
-                if ($year >= 1900 && $year <= $currentYear) {
-                    if ($oldestYear === null || $year < $oldestYear) {
-                        $oldestYear = $year;
-                    }
-                }
-            }
-        }
-    }
-
-    return $oldestYear;
-}
-
-/**
  * Evaluate a Shopify storefront URL for outreach fitness.
  *
  * Runs a pipeline of checks (agency detection, products count, age, country,

--- a/read-me/Email outreach.md
+++ b/read-me/Email outreach.md
@@ -16,6 +16,10 @@ Google Places finds small brick-and-mortar businesses.
 
 1. **Picks a city**, rotating through Saskatchewan first and then expanding outward into the rest of Canada.
 2. **Finds small businesses** there by category (plumbers, cafes, salons, and 90-odd other small-business types) and grabs their public contact email from their website.
+
+   The channel is biased toward new and early businesses (the ones least likely to already have accounting software):
+   - Businesses with more Google reviews than the review-count ceiling are skipped. The default is 15, since chains and long-established shops accrue lots of reviews. You can change it in Outreach, Settings (Discovery filters), and it also reads `OUTREACH_MAX_REVIEW_COUNT` from `.env`.
+   - Before drafting, the system reads the business's own website and skips ones that look clearly established: an old founding year (older than `OUTREACH_ESTABLISHED_MAX_AGE_YEARS`, default 8 years), copyright dates, or "20+ years experience" style claims. A cheap text check handles the obvious cases, then a quick AI pass catches softer signals (decades of awards, long client lists) with no literal year. Sparse, brand-new, or "now open" sites pass through. This is a deliberate skew, not a perfect classifier.
 3. **Writes each one a short email** with Gemini (currently `gemini-2.5-flash`). The email references the kind of business they run and the everyday headaches that category tends to have.
 4. **Runs a A/B test** alongside the send. It splits traffic across 2–4 variants and keeps the one that gets the most clicks or replies.
 5. **Sends the first emails**, up to the daily cap (`OUTREACH_DAILY_SEND_LIMIT`), with a tracked link so clicks can be attributed back to the lead and variant.
@@ -137,6 +141,7 @@ The Settings tab has two runtime controls plus the sequence configuration:
 
 - **Outreach system**: master enable/disable for the whole pipeline.
 - **Send mode**: Auto-send vs Review-before-send (affects both first emails AND follow-ups).
+- **Discovery filters**: the Google Places review-count ceiling. Lower it to bias discovery toward newer and smaller businesses; raise it to cast a wider net. Leave it blank to fall back to `OUTREACH_MAX_REVIEW_COUNT` in `.env` (or the built-in default of 15). The panel shows the value currently in effect and where it comes from.
 - **Follow-up sequence**: an editable table of touches. Each row is one touch: how many days after the previous touch it sends (1-90), and a default "intent" string that drives Gemini's wording (used when no follow-up A/B test is active). Add/remove rows for between 0 and 6 follow-up touches. Setting 0 touches disables follow-ups entirely.
 
 A/B automation runs unconditionally whenever the outreach system is enabled. The Settings tab also shows the active A/B test snapshot and a tail of the day's pipeline log for quick health checks.

--- a/tests/Smoke/test_outreach_filters_smoke.php
+++ b/tests/Smoke/test_outreach_filters_smoke.php
@@ -125,24 +125,79 @@ assert_true(filter_category_type_mismatch('plumber', null) === true,
 assert_true(filter_category_type_mismatch('plumber', []) === true,
     "empty types with expectation: mismatch");
 
-// ─── Section 5: filter_review_count_too_high ───
+// ─── Section 5: filter_review_count_too_high (default lowered to 15) ───
 echo "Section 5: filter_review_count_too_high\n";
 
-assert_true(filter_review_count_too_high(50) === false,    "50 reviews: pass");
-assert_true(filter_review_count_too_high(299) === false,   "299 reviews: pass (just under threshold)");
-assert_true(filter_review_count_too_high(300) === false,   "300 reviews: pass (at threshold, not over)");
-assert_true(filter_review_count_too_high(301) === true,    "301 reviews: reject");
+assert_true(filter_review_count_too_high(10) === false,    "10 reviews: pass (under default 15)");
+assert_true(filter_review_count_too_high(15) === false,    "15 reviews: pass (at default threshold, not over)");
+assert_true(filter_review_count_too_high(16) === true,     "16 reviews: reject (over default 15)");
+assert_true(filter_review_count_too_high(50) === true,     "50 reviews: reject (default lowered)");
 assert_true(filter_review_count_too_high(5000) === true,   "5000 reviews: reject (chain)");
 assert_true(filter_review_count_too_high(null) === false,  "null: pass (no signal)");
 assert_true(filter_review_count_too_high(0) === false,     "0: pass (new business)");
 assert_true(filter_review_count_too_high('') === false,    "empty string: pass");
 assert_true(filter_review_count_too_high('400') === true,  "stringified 400: still rejects");
 
-// Custom threshold
+// Custom threshold still honoured
 assert_true(filter_review_count_too_high(150, 100) === true,
     "custom threshold: 150 > 100");
 assert_true(filter_review_count_too_high(50, 100) === false,
     "custom threshold: 50 <= 100");
+
+// ─── Section 5b: outreach_max_review_count precedence (env -> default) ───
+// The DB-state branch isn't exercised here (no $pdo in this smoke harness);
+// it falls through to env, then to the built-in default of 15.
+echo "Section 5b: outreach_max_review_count\n";
+
+$savedEnv = $_ENV['OUTREACH_MAX_REVIEW_COUNT'] ?? null;
+
+$_ENV['OUTREACH_MAX_REVIEW_COUNT'] = '40';
+assert_true(outreach_max_review_count() === 40, "env override honoured (40)");
+
+$_ENV['OUTREACH_MAX_REVIEW_COUNT'] = '0';
+assert_true(outreach_max_review_count() === 15, "env 0 is invalid -> default 15");
+
+$_ENV['OUTREACH_MAX_REVIEW_COUNT'] = 'abc';
+assert_true(outreach_max_review_count() === 15, "env non-numeric -> default 15");
+
+unset($_ENV['OUTREACH_MAX_REVIEW_COUNT']);
+assert_true(outreach_max_review_count() === 15, "env unset -> default 15");
+
+// Restore whatever the environment had so later sections are unaffected.
+if ($savedEnv === null) { unset($_ENV['OUTREACH_MAX_REVIEW_COUNT']); }
+else { $_ENV['OUTREACH_MAX_REVIEW_COUNT'] = $savedEnv; }
+
+// ─── Section 5c: detect_established_signals (newness gate, pure regex) ───
+echo "Section 5c: detect_established_signals\n";
+
+$currentYear = (int) date('Y');
+$oldYear = $currentYear - 20;
+
+$sig = detect_established_signals("<p>Proudly serving the community since {$oldYear}.</p>");
+assert_true($sig['founded_year'] === $oldYear, "founded year detected from 'since YYYY'");
+
+$sig = detect_established_signals('<footer>&copy; ' . $oldYear . ' Acme Co. All rights reserved.</footer>');
+assert_true($sig['founded_year'] === $oldYear, "founded year detected from copyright");
+
+$sig = detect_established_signals('<h2>With over 25 years of experience in plumbing</h2>');
+assert_true($sig['years_experience'] === 25, "years experience detected ('over 25 years of experience')");
+
+$sig = detect_established_signals('<p>20+ years in business serving Saskatoon</p>');
+assert_true($sig['years_experience'] === 20, "years experience detected ('20+ years in business')");
+
+$sig = detect_established_signals('<h1>Now open! Fresh new bakery launching this spring.</h1>');
+assert_true($sig['founded_year'] === null && $sig['years_experience'] === null,
+    "brand-new site has no established signals (passes through)");
+
+$sig = detect_established_signals('<p>We sell handmade candles. Contact us today.</p>');
+assert_true($sig['founded_year'] === null && $sig['years_experience'] === null,
+    "sparse site has no established signals (passes through)");
+
+// detect_storefront_founded_year (shared with the Shopify evaluator)
+assert_true(detect_storefront_founded_year("<p>Founded in {$oldYear}.</p>") === $oldYear,
+    "detect_storefront_founded_year still works after move to shared helpers");
+assert_true(detect_storefront_founded_year('<p>no year here</p>') === null,
+    "detect_storefront_founded_year returns null when no signal");
 
 // ─── Section 6: _outreach_host_from (helper for chain-domain logic) ───
 echo "Section 6: _outreach_host_from\n";


### PR DESCRIPTION
## Why

Google Places discovery kept surfacing established businesses that already run accounting software, because the filters selected for "small and not-a-chain" but had no signal for *newness*. The review-count ceiling (300) filtered almost nothing, and the AI size gate only judged small-independent vs chain/corp, so a 20-year-old "Joe's Plumbing" sailed through.

This skews discovery toward new/early businesses (the ones least likely to have settled on accounting software). It's a deliberate skew, not a perfect classifier.

## Changes

**Review-count ceiling: lower + configurable**
- `filter_review_count_too_high()` default dropped 300 → 15.
- New `outreach_max_review_count()`: DB Settings knob (`max_review_count`) → `OUTREACH_MAX_REVIEW_COUNT` env → default 15. Wired into `search_businesses_core` (resolved once, not per candidate).
- New **Discovery filters** panel + `set_max_review_count` handler in the Settings tab (blank/0 = fall back to env/default; shows the value in effect and its source).

**Newness gate** — applied to `*_auto` leads in `generate_draft_for_lead`, before drafting:
- Layer A (free regex): `detect_established_signals()` rejects on an old founding year (≥ `OUTREACH_ESTABLISHED_MAX_AGE_YEARS`, default 8) or "20+ years experience" claims.
- Layer B (AI): `classify_business_maturity_with_ai()` catches softer signals (decades of awards, long client lists) with no literal year.
- Both **pass through on fetch/Gemini failure** so outreach is never blocked. The homepage is fetched once and the text reused by `summarize_business()`, so it's at most one extra GET, first draft only.
- `detect_storefront_founded_year()` moved to shared helpers (deduped from `shopify_discovery.php`) and now decodes `&copy;` entities.

## Notes
- No schema change (rides existing `outreach_pipeline_state`).
- Env templates (`.env -` files) carry `OUTREACH_MAX_REVIEW_COUNT=15` / `OUTREACH_ESTABLISHED_MAX_AGE_YEARS=8`; code defaults make these optional in production.
- Adds one website fetch + one Gemini "maturity" call per Google Places auto-lead at first draft. Acceptable for the goal, but a real per-lead cost/runtime increase in the cron.

## Testing
- `tests/Smoke/test_outreach_filters_smoke.php` updated (new default + helpers): **69/69 pass**.
- `tests/Smoke/test_shopify_discovery_smoke.php` (confirms the function move): **41/41 pass**.
- All changed PHP lints clean.

A Chamber of Commerce discovery channel was scoped out: Chamber members skew established / already-have-software, which works against this PR's goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)