### PR TITLE
Dedupe Shopify discovery results within a run

### DIFF
--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -673,6 +673,18 @@ function shopify_run_dork($pdo)
     $totalEvaluated       = 0;
     $queriesRun           = [];
 
+    // Within-run dedup. The same store surfaces across multiple dork queries
+    // (and via different deep links that all canonicalize to one origin), so
+    // without these we'd show (and re-evaluate) the same storefront many times.
+    //   $seenCanonicals: skip a canonical URL we've already processed this run,
+    //                    BEFORE the expensive evaluator call.
+    //   $seenIdentities: backstop for the case where two different canonical
+    //                    URLs resolve to the same final store + email (e.g. a
+    //                    .myshopify.com link and a custom-domain link for the
+    //                    same shop). Keyed on final-URL host + harvested email.
+    $seenCanonicals = [];
+    $seenIdentities = [];
+
     while (count($fits) < $limit && $callsToday < $serpapiLimit) {
         $query = SHOPIFY_DORK_POOL[$cursor % $poolSize];
         $cursor++;
@@ -695,6 +707,12 @@ function shopify_run_dork($pdo)
 
             $canonical = shopify_canonical_url($r['link'] ?? '');
             if ($canonical === '') continue;
+
+            // Skip canonicals already handled this run (dup SERP hits / deep
+            // links to the same store). Marked seen even if it later rejects,
+            // so we never pay to evaluate the same origin twice.
+            if (isset($seenCanonicals[$canonical])) continue;
+            $seenCanonicals[$canonical] = true;
 
             // Already-imported check FIRST, before the expensive evaluator
             // call. Uses outreach_shopify_candidates.canonical_url (stable,
@@ -719,11 +737,23 @@ function shopify_run_dork($pdo)
             }
 
             $meta = $result['metadata'] ?? [];
+            $finalUrl = $result['final_url'] ?? $canonical;
+
+            // Identity dedup: two different canonical URLs can resolve to the
+            // same shop (the Scholar's Choice case: many .myshopify.com links
+            // all redirect to scholarschoice.ca with the same email). Key on
+            // final-URL host + email so we only surface the store once.
+            $identityHost = parse_url($finalUrl, PHP_URL_HOST) ?: $canonical;
+            $identityHost = strtolower(preg_replace('/^www\./', '', (string) $identityHost));
+            $identityKey  = $identityHost . '|' . strtolower(trim((string) ($meta['email'] ?? '')));
+            if (isset($seenIdentities[$identityKey])) continue;
+            $seenIdentities[$identityKey] = true;
+
             $fits[] = [
                 'canonical_url'    => $canonical,
                 'serp_title'       => $r['title'] ?? '',
                 'fit'              => true,
-                'final_url'        => $result['final_url'] ?? $canonical,
+                'final_url'        => $finalUrl,
                 'business_name'    => $meta['business_name'] ?? '',
                 'email'            => $meta['email'] ?? '',
                 'products_count'   => $meta['products_count'] ?? null,


### PR DESCRIPTION
## Problem

The Shopify Discovery panel was showing the same store repeatedly, e.g. **Scholar's Choice 9 times** in a single 10-fit run.

## Cause

`shopify_run_dork()` only deduped against *already-imported* stores in the DB. It had no within-run dedup, so:
- the same storefront returned by several different dork queries, and
- different deep links that all canonicalize to one origin,

each got evaluated and pushed as a separate "fit." (The duplicates wouldn't create duplicate leads on import, since `shopify_import` dedupes by email/website, but they waste evaluator HTTP calls and make the table useless.)

## Fix

Two in-run guards in `shopify_run_dork`:
- **`$seenCanonicals`** — skip a canonical URL already processed this run, *before* the expensive evaluator call. Marked seen even on reject, so the same origin is never evaluated twice.
- **`$seenIdentities`** — backstop keyed on final-URL host + harvested email, for the case where two different canonical URLs resolve to the same shop (many `.myshopify.com` links redirecting to one custom domain, which is exactly the Scholar's Choice case).

## Notes
- Scoped to the Discovery UI run. The cron path already dedupes via the `outreach_shopify_candidates.canonical_url` unique key.
- Separately worth noting: Scholar's Choice is a long-established retailer that passed the evaluator because it keeps adding products (product-age check) and its homepage shows no founding year. Tightening the Shopify channel's established-business detection is a follow-up, not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)