### PR TITLE
Reddit relevance: reject out-of-category software requests

### DIFF
--- a/cron/lib/reddit_helpers.php
+++ b/cron/lib/reddit_helpers.php
@@ -709,12 +709,13 @@ A thread does NOT qualify (score ≤4) if:
 - It's a "best of" / "favorite tool" karma post with no specific problem
 - It's a complaint thread with no openness to alternatives
 - It's about an industry too large for Argo Books (enterprise, mid-market with employees, multi-entity)
+- The OP is primarily after software in a category Argo Books does NOT cover. Argo Books is bookkeeping and invoicing ONLY. Out-of-category requests include: point-of-sale (POS), payroll, CRM / lead management, e-commerce platforms or website builders, inventory / warehouse, ERP, appointment / scheduling, time-tracking, and project management. A passing mention of one of these alongside a genuine bookkeeping or invoicing need is fine (score on the bookkeeping need); but if the core ask is one of these categories, score ≤4 even when the OP is clearly and actively seeking software.
 
 Score 5–6 for borderline cases: relevant but ambiguous fit.
 
 Return JSON only: {"relevance": <0-10 integer>, "reason": "<one sentence>"}
 
-Do NOT consider whether any specific product is a good fit. Do NOT recommend a reply. Just score software-recommendation intent.
+Do NOT recommend a reply, and do NOT reason about whether Argo Books is the single best option among bookkeeping tools. But the intent MUST be for bookkeeping / accounting / invoicing software: strong software-recommendation intent for a DIFFERENT category (POS, payroll, CRM, e-commerce, inventory, ERP, scheduling, etc.) does NOT qualify and scores ≤4.
 SYS;
 
     $commentsBlock = empty($topComments)


### PR DESCRIPTION
## Problem

A r/smallbusiness thread asking for a **POS system with integrated rewards + a payroll system** scored **AI relevance 9/10** and was auto-drafted. Argo Books does neither (it's bookkeeping/invoicing), so the draft came out as a useless non-answer: *"I don't have experience with quick serve restaurant POS systems or integrated payroll for that kind of setup."*

## Cause

`reddit_ai_relevance()` uses deliberately neutral framing: *"Do NOT consider whether any specific product is a good fit... Just score software-recommendation intent."* That keeps the score from biasing toward yes, but it also means it scores **any** software request highly regardless of **category**. POS + payroll is a textbook software-rec post, so it scored 9 (≥ the `ai_relevance_floor` of 6) and got drafted.

The draft generator actually behaved correctly here, its prompt says to skip when "the question is about something Argo doesn't do well", so it declined to pitch. But the junk lead was still surfaced. Fixing the scorer is the root-cause fix.

## Fix

Tighten the relevance system prompt so strong software-rec intent for a category Argo Books doesn't cover scores ≤4 and never reaches drafting:
- New disqualifier for out-of-category requests: POS, payroll, CRM/lead management, e-commerce platforms / website builders, inventory/warehouse, ERP, appointment/scheduling, time-tracking, project management.
- A passing mention of one of these alongside a genuine bookkeeping/invoicing need still scores on the bookkeeping need (so we don't over-reject real leads that happen to mention payroll).
- Reworded the neutral-framing line so "don't reason about whether Argo is the single best tool" no longer bleeds into "ignore the software category."

## Notes
- Prompt-only change; no schema or control-flow change. Existing mis-scored threads age out via the 3-day auto-expire.
- No automated test (the scorer is a live Gemini call); validated by reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)