### PR TITLE
Fix site-wide hang while outreach discovery runs (session lock)

### DIFF
--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -32,6 +32,16 @@ if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
     }
 }
 
+// Release the session lock now that auth + CSRF have been read. PHP's default
+// file session handler holds an EXCLUSIVE lock from session_start() until the
+// request ends, so without this a long-running action (discovery can run for
+// minutes; shopify_run_dork even sets a 300s time limit) blocks every other
+// request carrying the same session cookie at its own session_start() — admin
+// pages AND public pages like the landing page would hang until it finished,
+// and concurrent discovery runs would serialize instead of overlapping. No
+// handler below writes to $_SESSION, so closing it here is safe.
+session_write_close();
+
 // Ensure tables exist
 
 // Check if the cron pipeline is currently running


### PR DESCRIPTION
## Problem

Running Google Places + Shopify + Reddit discovery at the same time made the whole site (including the public landing page) stop loading until the discovery finished.

## Cause

`admin/outreach/api.php` calls `session_start()` (line 2) for auth + CSRF and never closes the session. PHP's default file-based session handler holds an **exclusive lock** on the session file from `session_start()` until the request ends. Discovery actions run for minutes (`shopify_run_dork` sets `set_time_limit(300)`), so while one ran:

- every other request carrying the same session cookie blocked at its own `session_start()` — including admin pages and **public pages** (the root `index.php` landing page calls `session_start()` too), so they appeared to hang;
- the three discovery requests serialized behind each other instead of overlapping, because each waited for the session lock.

## Fix

Call `session_write_close()` immediately after auth and CSRF have been read, before dispatching to any handler. None of the api.php handlers write to `$_SESSION`, so releasing the lock early is safe. `$_SESSION` stays readable for the rest of the request; only the lock is released.

Effect: a long discovery run no longer blocks other requests in the same browser, the landing page loads normally, and the three channels can actually run concurrently.

## Notes
- This same pattern (long-running admin AJAX holding the session lock) likely exists in other admin endpoints; this PR only addresses the outreach api that triggered the report. Worth a follow-up sweep if you hit it elsewhere.
- Separate, deeper consideration (not in this PR): the discovery endpoints are synchronous long requests doing lots of external HTTP. On a small worker pool, several at once still consume capacity even without the session lock. If that becomes a problem, the real fix is moving discovery to a background job rather than an AJAX request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)