### PR TITLE
feat(api): AI operation timing priors (+ QuickBooks guide, shared-shell refactor)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -427,4 +427,5 @@ php_value upload_max_filesize 10M
     RewriteRule ^free-cash-flow-forecast-template/?$ articles/article-page.php?slug=free-cash-flow-forecast-template [L,QSA]
     RewriteRule ^cash-flow-forecasting-software/?$ articles/article-page.php?slug=cash-flow-forecasting-software [L,QSA]
     RewriteRule ^predictive-analytics-for-small-business/?$ articles/article-page.php?slug=predictive-analytics-for-small-business [L,QSA]
+    RewriteRule ^quickbooks-desktop-discontinued/?$ articles/article-page.php?slug=quickbooks-desktop-discontinued [L,QSA]
 </IfModule>

--- a/api/ai/_timing.php
+++ b/api/ai/_timing.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Server-side AI operation timing capture + aggregation.
+ *
+ * Records how long each desktop AI call actually takes ON THE SERVER (the Gemini
+ * wall time, isolated from the user's network), so the Argo Books desktop app can
+ * drive accurate, smooth progress bars from real pooled timings instead of a fake
+ * timer. Covers the two desktop AI endpoints:
+ *   - /api/ai/completions.php  (receipt scan, bank categorize, supplier suggestion,
+ *                               spreadsheet analysis/processing; tagged by the client
+ *                               via an "operation" field, default "completion")
+ *   - /api/bank/extract.php    (bank PDF extraction; tagged "bank_pdf_extract")
+ *
+ * Best-effort by design: NOTHING here may ever break a scan/extract response, so
+ * every DB call is wrapped and failures are logged and swallowed. Stores NO user or
+ * device identity (privacy; not needed for duration priors).
+ */
+
+require_once __DIR__ . '/../../db_connect.php';
+
+/**
+ * Creates the timings table on first use (mirrors the definition in mysql_schema.sql
+ * so a fresh server works without a manual migration). Runs at most once per request.
+ */
+function ai_timing_ensure_table(PDO $pdo): void
+{
+    static $done = false;
+    if ($done) {
+        return;
+    }
+    try {
+        $pdo->exec(
+            "CREATE TABLE IF NOT EXISTS ai_call_timings (
+                id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                operation VARCHAR(40) NOT NULL,
+                model VARCHAR(50) NOT NULL,
+                size_feature INT DEFAULT NULL,
+                page_count INT DEFAULT NULL,
+                input_bytes INT DEFAULT NULL,
+                mime VARCHAR(30) DEFAULT NULL,
+                prompt_tokens INT DEFAULT NULL,
+                output_tokens INT DEFAULT NULL,
+                max_output_tokens INT DEFAULT NULL,
+                finish_reason VARCHAR(20) DEFAULT NULL,
+                elapsed_ms INT NOT NULL,
+                poll_count INT DEFAULT NULL,
+                success TINYINT(1) NOT NULL DEFAULT 1,
+                app_platform VARCHAR(20) DEFAULT NULL,
+                environment ENUM('production','sandbox') NOT NULL DEFAULT 'production',
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                INDEX idx_op_model_created (operation, model, created_at),
+                INDEX idx_created (created_at)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+        );
+        $done = true;
+    } catch (Throwable $e) {
+        error_log('[ai-timing] ensure table failed: ' . $e->getMessage());
+    }
+}
+
+/**
+ * Best-effort INSERT of one timing sample. Never throws. Required keys: operation,
+ * model, elapsed_ms. All other keys are optional (see the column list).
+ */
+function ai_timing_record(array $row): void
+{
+    global $pdo;
+    if ($pdo === null) {
+        return;
+    }
+    if (empty($row['operation']) || empty($row['model']) || !isset($row['elapsed_ms'])) {
+        return;
+    }
+    try {
+        ai_timing_ensure_table($pdo);
+        $stmt = $pdo->prepare(
+            "INSERT INTO ai_call_timings
+                (operation, model, size_feature, page_count, input_bytes, mime,
+                 prompt_tokens, output_tokens, max_output_tokens, finish_reason,
+                 elapsed_ms, poll_count, success, app_platform, environment)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        );
+        $stmt->execute([
+            substr((string) $row['operation'], 0, 40),
+            substr((string) $row['model'], 0, 50),
+            ai_timing_int($row['size_feature'] ?? null),
+            ai_timing_int($row['page_count'] ?? null),
+            ai_timing_int($row['input_bytes'] ?? null),
+            isset($row['mime']) ? substr((string) $row['mime'], 0, 30) : null,
+            ai_timing_int($row['prompt_tokens'] ?? null),
+            ai_timing_int($row['output_tokens'] ?? null),
+            ai_timing_int($row['max_output_tokens'] ?? null),
+            isset($row['finish_reason']) ? substr((string) $row['finish_reason'], 0, 20) : null,
+            (int) $row['elapsed_ms'],
+            ai_timing_int($row['poll_count'] ?? null),
+            !empty($row['success']) ? 1 : 0,
+            isset($row['app_platform']) ? substr((string) $row['app_platform'], 0, 20) : null,
+            current_environment(),
+        ]);
+    } catch (Throwable $e) {
+        error_log('[ai-timing] record failed: ' . $e->getMessage());
+    }
+}
+
+/** Coerces a value to an int, or null when not set / not numeric. */
+function ai_timing_int($value): ?int
+{
+    if ($value === null || $value === '' || !is_numeric($value)) {
+        return null;
+    }
+    return (int) $value;
+}
+
+/**
+ * Current AI load factor: how much slower (or faster) calls are running RIGHT NOW
+ * versus their own recent baseline. 1.0 = normal, 1.4 = 40% slower than usual. Lets
+ * the client bias every estimate up/down when Gemini is busy. Each recent call is
+ * normalized by its own operation's 14-day average, so mixing operations is fine.
+ *
+ * Cached in a temp file for 60s so the latency-sensitive scan/extract path pays only
+ * a file read, not two DB queries, per call. Returns 1.0 (neutral) without enough
+ * recent signal.
+ */
+function ai_timing_load_factor(): float
+{
+    $cacheFile = sys_get_temp_dir() . '/ai_timing_load_factor_' . current_environment() . '.json';
+    if (is_file($cacheFile) && (time() - (int) @filemtime($cacheFile)) < 60) {
+        $cached = json_decode((string) @file_get_contents($cacheFile), true);
+        if (is_array($cached) && isset($cached['load_factor'])) {
+            return (float) $cached['load_factor'];
+        }
+    }
+    $factor = ai_timing_compute_load_factor();
+    @file_put_contents($cacheFile, json_encode(['load_factor' => $factor, 'at' => time()]));
+    return $factor;
+}
+
+/** Computes the load factor from the DB (see ai_timing_load_factor). */
+function ai_timing_compute_load_factor(): float
+{
+    global $pdo;
+    if ($pdo === null) {
+        return 1.0;
+    }
+    try {
+        $env = current_environment();
+
+        $stmt = $pdo->prepare(
+            "SELECT operation, AVG(elapsed_ms) AS base
+             FROM ai_call_timings
+             WHERE success = 1 AND finish_reason = 'STOP' AND environment = ?
+               AND created_at >= (NOW() - INTERVAL 14 DAY)
+             GROUP BY operation"
+        );
+        $stmt->execute([$env]);
+        $baseline = [];
+        foreach ($stmt->fetchAll() as $r) {
+            if ((float) $r['base'] > 0) {
+                $baseline[$r['operation']] = (float) $r['base'];
+            }
+        }
+        if (!$baseline) {
+            return 1.0;
+        }
+
+        $stmt = $pdo->prepare(
+            "SELECT operation, elapsed_ms
+             FROM ai_call_timings
+             WHERE success = 1 AND finish_reason = 'STOP' AND environment = ?
+               AND created_at >= (NOW() - INTERVAL 15 MINUTE)"
+        );
+        $stmt->execute([$env]);
+        $ratios = [];
+        foreach ($stmt->fetchAll() as $r) {
+            $op = $r['operation'];
+            if (isset($baseline[$op]) && $baseline[$op] > 0) {
+                $ratios[] = (float) $r['elapsed_ms'] / $baseline[$op];
+            }
+        }
+        if (count($ratios) < 5) {
+            return 1.0; // not enough recent signal -> neutral
+        }
+        $avg = array_sum($ratios) / count($ratios);
+        return round(max(0.3, min(4.0, $avg)), 3);
+    } catch (Throwable $e) {
+        error_log('[ai-timing] load factor failed: ' . $e->getMessage());
+        return 1.0;
+    }
+}
+
+/**
+ * Per-operation duration priors for the given model, computed in PHP from a bounded
+ * recent sample (last 14 days, capped). Returns one entry per operation with p50/p90
+ * (the spread that drives the smooth bar), plus averages the client uses to scale the
+ * estimate by document size. Excludes failed and truncated (non-STOP) calls.
+ *
+ * (A precomputed summary table refreshed by a cron is a future optimization; at the
+ * cache TTL and capped sample size this direct computation is cheap.)
+ */
+function ai_timing_compute_priors(string $model): array
+{
+    global $pdo;
+    if ($pdo === null) {
+        return [];
+    }
+    try {
+        ai_timing_ensure_table($pdo);
+        $stmt = $pdo->prepare(
+            "SELECT operation, elapsed_ms, size_feature, output_tokens, page_count
+             FROM ai_call_timings
+             WHERE success = 1 AND finish_reason = 'STOP'
+               AND environment = ? AND model = ?
+               AND created_at >= (NOW() - INTERVAL 14 DAY)
+             ORDER BY created_at DESC
+             LIMIT 20000"
+        );
+        $stmt->execute([current_environment(), $model]);
+
+        $byOp = [];
+        foreach ($stmt->fetchAll() as $r) {
+            $byOp[$r['operation']][] = $r;
+        }
+
+        $priors = [];
+        foreach ($byOp as $op => $rows) {
+            $elapsed = array_map(static fn($r) => (int) $r['elapsed_ms'], $rows);
+            sort($elapsed);
+            $priors[] = [
+                'operation' => $op,
+                'p50_ms' => ai_timing_percentile($elapsed, 0.50),
+                'p90_ms' => ai_timing_percentile($elapsed, 0.90),
+                'sample_count' => count($rows),
+                'avg_size_feature' => ai_timing_avg($rows, 'size_feature'),
+                'avg_output_tokens' => ai_timing_avg($rows, 'output_tokens'),
+                'per_page_ms' => ai_timing_per_page_ms($rows),
+            ];
+        }
+        return $priors;
+    } catch (Throwable $e) {
+        error_log('[ai-timing] compute priors failed: ' . $e->getMessage());
+        return [];
+    }
+}
+
+/** Nearest-rank percentile of an ascending-sorted int array. Null when empty. */
+function ai_timing_percentile(array $sorted, float $p): ?int
+{
+    $n = count($sorted);
+    if ($n === 0) {
+        return null;
+    }
+    $rank = (int) ceil($p * $n) - 1;
+    $rank = max(0, min($n - 1, $rank));
+    return (int) $sorted[$rank];
+}
+
+/** Average of a numeric column across rows, ignoring nulls. Null when none present. */
+function ai_timing_avg(array $rows, string $key): ?float
+{
+    $vals = [];
+    foreach ($rows as $r) {
+        if (isset($r[$key]) && $r[$key] !== null && $r[$key] !== '') {
+            $vals[] = (float) $r[$key];
+        }
+    }
+    if (!$vals) {
+        return null;
+    }
+    return round(array_sum($vals) / count($vals), 2);
+}
+
+/** Milliseconds per page (total elapsed / total pages) over rows that have a page count. */
+function ai_timing_per_page_ms(array $rows): ?float
+{
+    $pages = 0;
+    $ms = 0;
+    foreach ($rows as $r) {
+        $pc = isset($r['page_count']) ? (int) $r['page_count'] : 0;
+        if ($pc > 0) {
+            $pages += $pc;
+            $ms += (int) $r['elapsed_ms'];
+        }
+    }
+    if ($pages === 0) {
+        return null;
+    }
+    return round($ms / $pages, 2);
+}

--- a/api/ai/completions.php
+++ b/api/ai/completions.php
@@ -9,6 +9,7 @@
  */
 
 require_once __DIR__ . '/../portal/portal-helper.php';
+require_once __DIR__ . '/_timing.php';
 
 // Load environment variables
 require_once __DIR__ . '/../../vendor/autoload.php';
@@ -77,6 +78,13 @@ $maxTokens = max(1, min((int)($data['maxTokens'] ?? 4000), 16000)); // Clamp 1-1
 $temperature = max(0, min(2, (float)($data['temperature'] ?? 0.1)));
 $base64Image = $data['base64Image'] ?? null;
 $mimeType = $data['mimeType'] ?? 'image/jpeg';
+
+// Optional timing metadata sent by the desktop app so pooled duration priors can be
+// kept per operation (receipt scan vs spreadsheet analysis vs bank categorize, which
+// are otherwise indistinguishable here). Absent/older clients default to 'completion'.
+$operation = isset($data['operation']) ? (string) $data['operation'] : 'completion';
+$sizeFeature = isset($data['sizeFeature']) && is_numeric($data['sizeFeature']) ? (int) $data['sizeFeature'] : null;
+$appPlatform = isset($data['platform']) ? (string) $data['platform'] : null;
 
 // Validate model: Gemini is the only supported provider
 $geminiModels = ['gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-2.0-flash'];
@@ -221,6 +229,10 @@ if ($systemInstruction) {
 
 $geminiUrl = "https://generativelanguage.googleapis.com/v1beta/models/{$model}:generateContent";
 
+// Server-measured Gemini wall time (isolated from the user's network) feeds the
+// timing priors and the response 'timing' block.
+$aiTimingStart = microtime(true);
+
 $ch = curl_init($geminiUrl);
 curl_setopt_array($ch, [
     CURLOPT_RETURNTRANSFER => true,
@@ -235,6 +247,7 @@ curl_setopt_array($ch, [
 ]);
 
 $response = curl_exec($ch);
+$aiElapsedMs = (int) round((microtime(true) - $aiTimingStart) * 1000);
 $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 $curlError = curl_error($ch);
 
@@ -307,11 +320,33 @@ if ($content === null) {
     send_error_response(502, 'Invalid response from AI service.', 'UPSTREAM_ERROR');
 }
 
+// Record the server-measured timing (best-effort; never breaks the response).
+ai_timing_record([
+    'operation' => $operation,
+    'model' => $model,
+    'size_feature' => $sizeFeature,
+    'input_bytes' => !empty($base64Image) ? (int) (strlen($base64Image) * 0.75) : strlen($userPrompt),
+    'mime' => !empty($base64Image) ? $mimeType : null,
+    'prompt_tokens' => $usage['prompt_tokens'] ?? null,
+    'output_tokens' => $usage['completion_tokens'] ?? null,
+    'max_output_tokens' => $maxTokens,
+    'finish_reason' => $finishReason,
+    'elapsed_ms' => $aiElapsedMs,
+    'success' => true,
+    'app_platform' => $appPlatform,
+]);
+
 send_json_response(200, [
     'success' => true,
     'content' => $content,
     'model' => $model,
     'usage' => $usage,
     'finishReason' => $finishReason,
+    'timing' => [
+        'elapsed_ms' => $aiElapsedMs,
+        'prompt_tokens' => $usage['prompt_tokens'] ?? 0,
+        'output_tokens' => $usage['completion_tokens'] ?? 0,
+        'load_factor' => ai_timing_load_factor(),
+    ],
     'timestamp' => date('c'),
 ]);

--- a/api/ai/timing-priors.php
+++ b/api/ai/timing-priors.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * GET /api/ai/timing-priors.php
+ *
+ * Serves aggregated AI-operation timing priors for the CURRENTLY CONFIGURED Gemini
+ * model so the Argo Books desktop app can drive accurate, smooth progress bars. The
+ * app fetches this occasionally and caches it; when the model is swapped server-side,
+ * the priors retrain from real traffic with no app release.
+ *
+ * Read-only. Auth is optional (used only for rate-limit bucketing). 1h HTTP cache.
+ *
+ * Response:
+ *   { "success": true, "model": "gemini-2.5-flash", "window_days": 14,
+ *     "load_factor": 1.0,
+ *     "priors": [ { "operation": "...", "p50_ms": ..., "p90_ms": ...,
+ *                   "sample_count": ..., "avg_size_feature": ...,
+ *                   "avg_output_tokens": ..., "per_page_ms": ... }, ... ],
+ *     "generated_at": "..." }
+ */
+
+require_once __DIR__ . '/../portal/portal-helper.php';
+require_once __DIR__ . '/_timing.php';
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
+$dotenv->safeLoad();
+
+set_portal_headers();
+require_method(['GET']);
+
+// Optional identity, used ONLY to bucket the rate limit (no auth required to read).
+$deviceHash = authenticate_device_request();
+$license = $deviceHash ? null : authenticate_license_request();
+$rateLimitId = $license
+    ? substr($license['license_key_hash'], 0, 16)
+    : ($deviceHash ? substr($deviceHash, 0, 16) : substr(hash('sha256', get_client_ip()), 0, 16));
+if (is_rate_limited($rateLimitId, 120, 900, 'ai_priors')) {
+    send_error_response(429, 'Rate limit exceeded. Please try again later.', 'RATE_LIMITED');
+}
+record_rate_limit_attempt($rateLimitId, 'ai_priors');
+
+$model = $_ENV['GEMINI_MODEL'] ?? 'gemini-2.5-flash';
+
+// p50/p90 change slowly, so a 1h shared cache is fine. load_factor is recomputed at
+// most every 60s server-side, so occasional client polls still see it move.
+header('Cache-Control: public, max-age=3600');
+
+send_json_response(200, [
+    'success' => true,
+    'model' => $model,
+    'window_days' => 14,
+    'load_factor' => ai_timing_load_factor(),
+    'priors' => ai_timing_compute_priors($model),
+    'generated_at' => date('c'),
+]);

--- a/api/bank/extract.php
+++ b/api/bank/extract.php
@@ -16,6 +16,7 @@
  */
 
 require_once __DIR__ . '/../portal/portal-helper.php';
+require_once __DIR__ . '/../ai/_timing.php';
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../../');
@@ -72,6 +73,10 @@ if (substr($pdfBytes, 0, 5) !== '%PDF-') {
     send_error_response(415, 'That file does not look like a PDF.', 'BAD_TYPE');
 }
 
+// Page count is the strongest up-front predictor of extraction time; capture it for
+// the timing priors (best-effort heuristic, null when it can't be determined).
+$pageCount = bs_pdf_page_count($pdfBytes);
+
 // --- 4. Config ---
 $geminiKey = $_ENV['GEMINI_API_KEY'] ?? '';
 if ($geminiKey === '') {
@@ -84,13 +89,16 @@ $fileName = bs_upload_pdf($geminiKey, $pdfBytes);
 if ($fileName === null) {
     send_error_response(502, 'Failed to upload the PDF to the extraction service.', 'UPSTREAM_ERROR');
 }
-if (!bs_wait_active($geminiKey, $fileName)) {
+$pollCount = 0;
+if (!bs_wait_active($geminiKey, $fileName, $pollCount)) {
     bs_delete_file($geminiKey, $fileName);
     send_error_response(502, 'The extraction service could not process the PDF.', 'UPSTREAM_ERROR');
 }
 
 // --- 6. Ask the model to extract the rows. ---
-$content = bs_call_gemini($geminiKey, $model, $fileName);
+$extractElapsedMs = null;
+$extractUsage = null;
+$content = bs_call_gemini($geminiKey, $model, $fileName, $extractElapsedMs, $extractUsage);
 bs_delete_file($geminiKey, $fileName); // store nothing past this point
 
 if ($content === null) {
@@ -99,11 +107,34 @@ if ($content === null) {
 
 $lines = bs_normalize_lines($content);
 
+// Record the server-measured timing (best-effort; never breaks the response).
+ai_timing_record([
+    'operation' => 'bank_pdf_extract',
+    'model' => $model,
+    'size_feature' => strlen($pdfBytes),
+    'page_count' => $pageCount,
+    'input_bytes' => strlen($pdfBytes),
+    'mime' => 'application/pdf',
+    'prompt_tokens' => $extractUsage['promptTokenCount'] ?? null,
+    'output_tokens' => $extractUsage['candidatesTokenCount'] ?? null,
+    'max_output_tokens' => 16000,
+    'finish_reason' => 'STOP',
+    'elapsed_ms' => $extractElapsedMs ?? 0,
+    'poll_count' => $pollCount,
+    'success' => true,
+]);
+
 // A valid-but-empty result (no transactions found) is still success: the client
 // shows its own "no transactions" message. Hard failures returned errors above.
 send_json_response(200, [
     'success' => true,
     'lines' => $lines,
+    'timing' => [
+        'elapsed_ms' => $extractElapsedMs ?? 0,
+        'prompt_tokens' => $extractUsage['promptTokenCount'] ?? 0,
+        'output_tokens' => $extractUsage['candidatesTokenCount'] ?? 0,
+        'load_factor' => ai_timing_load_factor(),
+    ],
     'timestamp' => date('c'),
 ]);
 
@@ -159,10 +190,11 @@ function bs_upload_pdf(string $geminiKey, string $pdfBytes): ?string
  * Polls the uploaded file until it reaches ACTIVE state (Gemini processes uploads
  * asynchronously). Returns true once ACTIVE, false on FAILED or timeout (~7.5s).
  */
-function bs_wait_active(string $geminiKey, string $fileName): bool
+function bs_wait_active(string $geminiKey, string $fileName, int &$pollCount = 0): bool
 {
     $statusUrl = "https://generativelanguage.googleapis.com/v1beta/{$fileName}";
     for ($i = 0; $i < 15; $i++) {
+        $pollCount = $i + 1;
         $ch = curl_init($statusUrl);
         curl_setopt_array($ch, [
             CURLOPT_RETURNTRANSFER => true,
@@ -196,8 +228,12 @@ function bs_delete_file(string $geminiKey, string $fileName): void
     curl_exec($ch);
 }
 
-/** Calls Gemini generateContent referencing the uploaded PDF. Returns the JSON text or null. */
-function bs_call_gemini(string $geminiKey, string $model, string $fileName): ?string
+/**
+ * Calls Gemini generateContent referencing the uploaded PDF. Returns the JSON text or null.
+ * Reports the server-measured wall time (ms) and Gemini usageMetadata via by-ref params
+ * for the timing priors.
+ */
+function bs_call_gemini(string $geminiKey, string $model, string $fileName, ?int &$elapsedMs = null, ?array &$usage = null): ?string
 {
     $fileUri = "https://generativelanguage.googleapis.com/v1beta/{$fileName}";
 
@@ -249,13 +285,16 @@ PROMPT;
         CURLOPT_TIMEOUT => 120,
         CURLOPT_CONNECTTIMEOUT => 10,
     ]);
+    $t0 = microtime(true);
     $resp = curl_exec($ch);
+    $elapsedMs = (int) round((microtime(true) - $t0) * 1000);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     if ($resp === false || $httpCode !== 200) {
         error_log('[bank-extract] Gemini error ' . $httpCode . ': ' . substr((string)$resp, 0, 500));
         return null;
     }
     $data = json_decode($resp, true);
+    $usage = $data['usageMetadata'] ?? null;
     $candidate = $data['candidates'][0] ?? [];
     // gemini-2.5-flash spends hidden "thinking" tokens out of maxOutputTokens; log any
     // non-STOP finish so truncation on a very long statement is visible, not silent.
@@ -308,4 +347,18 @@ function bs_normalize_lines(string $content): array
         ];
     }
     return $out;
+}
+
+/**
+ * Best-effort page count from raw PDF bytes, used only as a timing size-feature.
+ * Counts "/Type /Page" objects (the word boundary excludes the "/Pages" tree node).
+ * Returns null when it cannot be determined; never throws.
+ */
+function bs_pdf_page_count(string $pdfBytes): ?int
+{
+    if (@preg_match_all('/\/Type\s*\/Page\b/', $pdfBytes, $m)) {
+        $count = count($m[0]);
+        return $count > 0 ? $count : null;
+    }
+    return null;
 }

--- a/articles/article-page.php
+++ b/articles/article-page.php
@@ -16,7 +16,7 @@
 //   <h2>            Related guides
 //   <h2>            Related articles (when $data['related_article_slugs'] non-empty)
 
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 require_once __DIR__ . '/../config/pricing.php';
 require_once __DIR__ . '/illustrations.php';
 
@@ -484,7 +484,16 @@ document.addEventListener('DOMContentLoaded', function () {
 </script>
 HTML;
 
-include __DIR__ . '/../invoice-generator/layout.php';
+// Editorial header nav for guide pages. Content/credibility links only,
+// deliberately no Pricing or buy CTA so the page reads as a blog, not a
+// funnel. The shared tool layout renders this only when it is set.
+$header_nav = [
+  ['label' => 'Guides',        'href' => 'guides/'],
+  ['label' => 'Docs',          'href' => 'documentation/'],
+  ['label' => 'About',         'href' => 'about-us/'],
+];
+
+include __DIR__ . '/../shared/layout.php';
 
 // -----------------------------------------------------------------------------
 

--- a/articles/data/best-quickbooks-alternatives.php
+++ b/articles/data/best-quickbooks-alternatives.php
@@ -20,7 +20,7 @@ return [
 
   'published' => '2026-05-31',
 
-  'updated' => '2026-06-26',
+  'updated' => '2026-06-29',
 
   'reading_time_min' => 10,
 
@@ -40,7 +40,7 @@ HTML,
       'html' => <<<'HTML'
 <p>It helps to be clear about which problem you're actually trying to solve, because each one points at a different replacement.</p>
 <ul>
-<li><strong>Price.</strong> The most common reason. Entry plans start around ${quickbooks_easystart} CAD a month, but the features most businesses want sit in Plus, closer to ${quickbooks_plus} CAD a month, and the published price tends to rise each year. If cost is the driver, free and low-cost options below will feel like a different world.</li>
+<li><strong>Price.</strong> The most common reason. Entry plans start around ${quickbooks_easystart} CAD a month, but the features most businesses want sit in Plus, closer to ${quickbooks_plus} CAD a month, and the published price keeps climbing: the popular Plus plan rose by around two-thirds in the five years to 2025 (<a href="https://report.woodard.com/articles/intuit-announces-2025-quickbooks-price-increases-fpwr" target="_blank" rel="noopener nofollow">pricing updates</a>). If cost is the driver, free and low-cost options below will feel like a different world.</li>
 <li><strong>Complexity.</strong> QuickBooks is built to do almost everything, which makes it slow and busy if you only need a fraction of it. If you spend more time hunting through menus than doing the task, a simpler tool will save you hours.</li>
 <li><strong>Feature gatekeeping.</strong> Things you'd consider basic, like more detailed reports or certain integrations, are often held back for higher tiers. If you're paying for Plus to unlock one feature you use, a different tool may include it lower down.</li>
 <li><strong>You've outgrown it the other way.</strong> Less common, but some businesses leave because they need something more specialized, like heavy inventory or a specific industry workflow QuickBooks doesn't handle well.</li>

--- a/articles/data/quickbooks-desktop-discontinued.php
+++ b/articles/data/quickbooks-desktop-discontinued.php
@@ -1,0 +1,171 @@
+<?php
+// articles/data/quickbooks-desktop-discontinued.php
+// See articles/data/_template.php for schema.
+
+return [
+
+  'slug' => 'quickbooks-desktop-discontinued',
+
+  'h1' => 'QuickBooks Desktop discontinued: what it means and your options',
+
+  'meta_title' => 'QuickBooks Desktop Discontinued: What to Do | Argo Books',
+
+  'meta_description' => 'QuickBooks Desktop is being wound down. What Intuit has stopped selling, the support end dates, what stops working, and your real options including a free local alternative.',
+
+  'schema_type' => 'Article',
+
+  'category' => 'choosing-software',
+  'hub_weight' => 15,
+
+  'published' => '2026-06-29',
+
+  'updated' => '2026-06-29',
+
+  'reading_time_min' => 10,
+
+  'total_time_iso8601' => null,
+
+  'intro_html' => <<<'HTML'
+<p>If you run QuickBooks Desktop, you have probably heard that it's going away. The headlines make it sound sudden, but the reality is calmer and more useful to understand. Intuit has stopped selling QuickBooks Desktop to new customers and is steadily winding down support for the versions still in use. Your software has not stopped working, and you are not locked out tomorrow. What is changing is that the clock is now running.</p>
+<p>This guide lays out exactly what Intuit has announced, what actually stops working when support ends, and the real choices in front of you: keep renewing while you can, move to QuickBooks Online, or switch to something else. It also walks through a practical way to get your data out of QuickBooks as a spreadsheet and into a free tool, so whatever you decide, your records come with you.</p>
+HTML,
+
+  'sections' => [
+
+    [
+      'h2' => 'What Intuit has actually announced',
+      'anchor' => 'what-changed',
+      'html' => <<<'HTML'
+<p>It helps to separate the facts from the noise, because "discontinued" is doing a lot of work in the headlines. Here is what Intuit has actually confirmed.</p>
+<ul>
+<li><strong>New sales have stopped.</strong> After September 30, 2024, Intuit <a href="https://quickbooks.intuit.com/r/whats-new/quickbooks-desktop-stop-sell/" target="_blank" rel="noopener nofollow">stopped selling new QuickBooks Desktop subscriptions</a> to most new customers. If you already have a subscription, you can keep renewing it.</li>
+<li><strong>No new versions are coming.</strong> QuickBooks Desktop 2024 is the final yearly release of Pro Plus, Premier Plus, and Mac Plus. There is no 2025 or 2026 edition.</li>
+<li><strong>Each version has a support end date.</strong> Per Intuit's <a href="https://quickbooks.intuit.com/learn-support/en-us/help-article/feature-preferences/quickbooks-desktop-service-discontinuation-policy/L17cXxlie_US_en_US" target="_blank" rel="noopener nofollow">discontinuation policy</a>, QuickBooks Desktop 2023 stops getting services and support after May 31, 2026. The 2024 version is supported into 2027.</li>
+<li><strong>Enterprise is the exception.</strong> QuickBooks Desktop Enterprise is still sold to new customers and is not part of this wind-down, though Intuit increasingly steers Enterprise users toward cloud hosting.</li>
+</ul>
+<p>So the honest framing is not "QuickBooks Desktop is dead." It's being retired in stages. New people cannot buy it, existing users can renew for now, and the connected services behind it have a published expiry date. If your version is 2023, your date is the one to mark on the calendar. If you want a wider view of whether QuickBooks still fits your business at all, the guide on <a href="/is-quickbooks-worth-it-for-small-business/">whether QuickBooks is worth it</a> is a good companion to this one.</p>
+HTML,
+    ],
+
+    [
+      'h2' => 'What actually stops working when support ends',
+      'anchor' => 'what-stops',
+      'html' => <<<'HTML'
+<p>This is the part that matters, because the software itself does not switch off. After your version's support date passes, you can still open the program, look at your books, and run reports. What you lose is everything that depends on Intuit's servers behind the scenes:</p>
+<ul>
+<li><strong>Payroll.</strong> Tax tables stop updating, so any payroll you run inside QuickBooks Desktop will calculate withholding on out-of-date rates. This is the one that bites first for businesses with staff.</li>
+<li><strong>Bank feeds.</strong> The automatic download of transactions from your bank stops. You can still bring transactions in by hand from a CSV file, but the live connection ends.</li>
+<li><strong>Payments.</strong> Taking card or online payments through QuickBooks stops working.</li>
+<li><strong>Security updates.</strong> No more patches. For software that holds your financial records, running a version that no longer receives updates is a real consideration, not a small one.</li>
+<li><strong>Live support.</strong> Intuit's phone and chat help for that version ends.</li>
+</ul>
+<p>None of this happens on day one of buying the software. It happens on the published support date for your version. The practical takeaway: you have time to plan, but the features that quietly do the most work, payroll and bank feeds, are exactly the ones that go. That is why drifting along on an unsupported version is fine for a read-only archive and risky for a business you are actively running.</p>
+HTML,
+    ],
+
+    [
+      'h2' => 'Your three real options',
+      'anchor' => 'your-options',
+      'html' => <<<'HTML'
+{{illustration:compare-scale}}
+<p>There is no single right answer here. There are three honest paths, and the best one depends on what you actually use QuickBooks for.</p>
+<h3>Option 1: keep renewing while you can</h3>
+<p>If you are on a version that still has support runway and your setup works, you can simply keep paying the yearly renewal. This buys you time, not a long-term home. Renewal prices have been climbing year over year, and the end date does not move, so this is best treated as a bridge while you decide, not a destination.</p>
+<h3>Option 2: move to QuickBooks Online</h3>
+<p>This is the path Intuit is steering everyone toward, and for some businesses it's the right one. QuickBooks Online has genuine strengths: you can reach your books from any device, updates and security are handled for you, and an accountant can log into the same file from their office. If your accountant already lives in QuickBooks Online and your payroll runs through Intuit, the move keeps everything in one place.</p>
+<p>The trade-offs are just as real, and worth saying plainly. QuickBooks Online is subscription-only and cloud-only: your books live on Intuit's servers, not your computer, and you pay every month for as long as you use it. Published prices have also climbed steeply: in the US the entry Simple Start plan rose from about $25 a month in 2020 to $38 in 2025, and the popular Plus plan from about $70 to $115, roughly two-thirds more in five years (<a href="https://report.woodard.com/articles/intuit-announces-2025-quickbooks-price-increases-fpwr" target="_blank" rel="noopener nofollow">pricing updates</a>). Some long-time Desktop users also find the online version weaker on inventory and certain detailed workflows. It's a fair option, not a free lunch.</p>
+<h3>Option 3: switch to a different tool</h3>
+<p>You are not limited to Intuit's own upgrade path. Plenty of small businesses use the discontinuation as the moment to move to something simpler, cheaper, or local. The <a href="/best-quickbooks-alternatives/">roundup of QuickBooks alternatives</a> covers the main names with honest trade-offs, and the comparison of <a href="/one-time-purchase-vs-subscription-accounting-software/">one-time-purchase versus subscription software</a> is worth a read if the monthly-fee model is part of why you are leaving. The rest of this guide focuses on one path that the QuickBooks Online route cannot offer: keeping your books on your own machine.</p>
+HTML,
+    ],
+
+    [
+      'h2' => 'Keeping your books local instead',
+      'anchor' => 'stay-local',
+      'html' => <<<'HTML'
+<p>A lot of the frustration with the QuickBooks wind-down is not really about QuickBooks. It's about being told that the only way forward is to move your financial records to someone else's cloud and pay monthly forever. For some businesses that is fine. For others, privacy, speed, and not renting access to their own books matter, and that is a perfectly reasonable preference.</p>
+<p>Local-first software is the answer to that preference. The program runs on your computer, your data file lives on your machine, and it keeps working at full speed whether or not you are online. QuickBooks Desktop used to feel like this, which is part of why long-time users are unhappy about being pushed to the cloud.</p>
+<p>Argo Books is one local-first option, and since you are reading this on its site, treat the mention with that in mind. It's a desktop app for Windows, Linux, and macOS, with a free tier that has no time limit: {argo_free_invoice_limit} invoices a month, basic bookkeeping, and your data kept on your own machine. Premium is ${argo_premium_monthly} CAD a month for higher volumes and more features.</p>
+<p>Be clear about what it isn't, because that honesty is the point. Argo Books does not have built-in payroll, so if you pay staff through QuickBooks you will need a separate payroll service. It has a smaller feature set than QuickBooks Desktop Enterprise and a smaller accountant ecosystem than the big names. What it does well is the core that most small businesses actually use every day: invoicing, expenses, receipts, basic inventory, and reports, all on your own computer. If you run payroll or need heavy multi-entity accounting, stay with a tool built for that. If you want simple, private, and local, it's worth a look.</p>
+HTML,
+    ],
+
+    [
+      'h2' => 'How to move your data from QuickBooks into a free tool',
+      'anchor' => 'move-your-data',
+      'html' => <<<'HTML'
+{{illustration:spreadsheet-to-books}}
+<p>Here is the part the cloud-migration guides skip: you can take your QuickBooks data out as plain spreadsheets and bring it into Argo Books for free, with no conversion deadline and no lock-in. Once your records are in a spreadsheet, they are yours. There is no 60-day window like the one QuickBooks Online imposes on its own conversion, because a spreadsheet is just a file on your computer.</p>
+<h3>Step 1: export your lists from QuickBooks Desktop</h3>
+<p>QuickBooks Desktop does not have a single "export everything" button, so you export the pieces you need. Start with your reference lists. In the Customer Center, Vendor Center, and Item List, use the Excel or Export button to save each as a spreadsheet. That captures your customers, your suppliers, and your products in three clean files.</p>
+<h3>Step 2: export your transaction history</h3>
+<p>For the actual money movements, run the reports you want and export them. A sales report gives you your income history, an expense or purchases report gives you what you spent, and a Profit and Loss Detail report gives you a broad transaction list for a period. Each report has an Export to Excel option. Save them as .xlsx or CSV. Pick the date range you care about, usually the current and previous fiscal year.</p>
+<h3>Step 3: import the spreadsheets into Argo Books</h3>
+<p>In Argo Books, open the import tool and choose Spreadsheet, then pick one of your files. It reads CSV and Excel files, works out what kind of data each sheet holds, and proposes how the columns line up, so you are not hand-matching every field. You review the mapping, confirm, and it brings the records in. If an invoice points at a customer that is not in the system yet, it can create that customer for you rather than failing. The whole import can be undone if something does not look right, so you can experiment safely.</p>
+<p>Spreadsheet import is part of the free tier, and the monthly allowance for the smart column-matching is far larger than a one-time migration needs, so moving your history across costs nothing. If your main goal is just the bank-transaction history, the dedicated guide on <a href="/import-bank-transactions-from-csv-into-accounting-software/">importing bank transactions from CSV</a> walks through that specific case, and the general <a href="/how-to-convert-excel-spreadsheet-to-accounting-software/">spreadsheet-to-software conversion guide</a> covers tidying messy exports first.</p>
+<h3>Step 4: keep QuickBooks around for a while</h3>
+<p>Do not cancel QuickBooks the day you import. Keep it accessible for a month or two so you can look up anything the export did not carry, like a custom report layout or an old attachment. Once you are confident nothing is missing, you can let it go. Chart-of-accounts structure and any custom automation do not travel through a spreadsheet, so those are the things to double-check on the way out.</p>
+HTML,
+    ],
+
+    [
+      'h2' => 'Is this the right move for you?',
+      'anchor' => 'is-it-right',
+      'html' => <<<'HTML'
+<p>To keep this honest, here is who each path actually suits.</p>
+<ul>
+<li><strong>Stay on QuickBooks Online</strong> if your accountant works inside your QuickBooks file, you run payroll through Intuit, or you need heavy inventory and multi-user access that a simpler tool will not match. The monthly cost buys real things in that case.</li>
+<li><strong>Move to a free, local tool like Argo Books</strong> if you are a small business whose day-to-day is invoicing, expenses, receipts, and basic reports, you do not run payroll through your accounting software, and you would rather keep your books on your own machine than rent cloud access forever.</li>
+<li><strong>Keep renewing for now</strong> if you are simply not ready to decide, and you want a bridge while you plan the real move. Just remember the support date does not wait.</li>
+</ul>
+<p>The QuickBooks Desktop wind-down is a genuine nuisance, but it's also a clean moment to ask what you actually need. Most small businesses use a fraction of what QuickBooks offers. If that is you, being pushed off the old software might be the nudge to land somewhere simpler and cheaper, with your records safely in your own hands either way.</p>
+HTML,
+    ],
+
+  ],
+
+  'callout_after_section_index' => 4,
+
+  'tool_callout_text' => 'Argo Books is free to try, runs on your own computer, and imports your QuickBooks data straight from a spreadsheet.',
+  'tool_callout_cta' => 'Try Argo Books for free',
+  'tool_callout_url' => '/downloads/',
+
+  'faqs' => [
+    [
+      'q' => 'Is QuickBooks Desktop really being discontinued?',
+      'a' => 'In stages, yes. Intuit stopped selling new QuickBooks Desktop subscriptions to most new customers after September 30, 2024, and there are no new yearly versions after the 2024 release. Each existing version has a support end date: the 2023 version loses services and support after May 31, 2026, and 2024 is supported into 2027. Enterprise is the exception and is still sold. So it\'s a managed wind-down rather than an overnight shutdown, but the end dates are real and published.',
+    ],
+    [
+      'q' => 'Can I keep using QuickBooks Desktop after support ends?',
+      'a' => 'The software itself keeps opening, so you can still view your books and run reports on an unsupported version. What you lose are the connected services: payroll tax tables stop updating, automatic bank feeds and online payments stop, security patches end, and live support ends. That makes an unsupported version fine as a read-only archive but risky for a business you are actively running, especially if you process payroll.',
+    ],
+    [
+      'q' => 'Do I have to move to QuickBooks Online?',
+      'a' => 'No. QuickBooks Online is the path Intuit promotes, and it suits some businesses, but it\'s not your only option. You can keep renewing a supported Desktop version for now, or switch to a different tool entirely, including local-first software that keeps your books on your own computer instead of in the cloud. The right choice depends on whether you need things like built-in payroll and accountant access, or mainly want simple, private bookkeeping.',
+    ],
+    [
+      'q' => 'How do I get my data out of QuickBooks Desktop?',
+      'a' => 'QuickBooks Desktop does not have one button that exports everything, so you export in pieces. Use the Excel or Export button in the Customer Center, Vendor Center, and Item List to save your lists, then run the reports you want (a sales report, an expenses report, a Profit and Loss Detail) and use Export to Excel for your transaction history. Save the files as Excel or CSV. Once your data is in spreadsheets it\'s portable, with no conversion deadline attached.',
+    ],
+    [
+      'q' => 'Can I import my QuickBooks data into Argo Books for free?',
+      'a' => 'Yes. Argo Books imports CSV and Excel files on its free tier. You export your QuickBooks lists and reports to spreadsheets, then import them: the tool works out what each sheet contains and proposes how the columns map, so you are not matching fields by hand, and it can create any missing customers or suppliers as it goes. The monthly allowance for the smart matching is far more than a one-time migration uses, and the whole import can be undone, so moving your history across costs nothing and is safe to try.',
+    ],
+    [
+      'q' => 'Does Argo Books have payroll?',
+      'a' => 'No, Argo Books does not have built-in payroll. If you currently run payroll through QuickBooks, you would need a separate payroll service alongside it. This is the main reason some businesses should not switch: if payroll inside your accounting software matters to you, stay with a tool that offers it. Argo Books is aimed at the core that most small businesses use daily, invoicing, expenses, receipts, basic inventory, and reports, on your own machine.',
+    ],
+  ],
+
+  'related_niche_slugs' => [
+    'freelance',
+    'contractor',
+    'consultant',
+  ],
+
+  'related_article_slugs' => [
+    'best-quickbooks-alternatives',
+    'one-time-purchase-vs-subscription-accounting-software',
+    'is-quickbooks-worth-it-for-small-business',
+  ],
+];

--- a/craft-pricing-calculator/index.php
+++ b/craft-pricing-calculator/index.php
@@ -6,7 +6,7 @@
 // layout.php): header, "All tools" breadcrumb, OG/Twitter/canonical, schema.
 // Calculation is client-side (scripts/main.js + calc.js).
 
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 
 if (PHP_SAPI !== 'cli') {
     require_once __DIR__ . '/../statistics.php';
@@ -283,4 +283,4 @@ ob_start();
 <?php
 $body_content = ob_get_clean();
 
-include __DIR__ . '/../invoice-generator/layout.php';
+include __DIR__ . '/../shared/layout.php';

--- a/estimate-generator/index.php
+++ b/estimate-generator/index.php
@@ -8,7 +8,7 @@
 // defers to the same layout.php + main.js. See invoice-generator/doc-config.php
 // for the full config and the consolidation rationale.
 
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 require_once __DIR__ . '/../invoice-generator/doc-config.php';
 
 $doc_type = 'estimate';
@@ -57,4 +57,4 @@ $body_content = ob_get_clean();
 $extra_scripts = '<script type="module" src="' . INVGEN_BASE . '/invoice-generator/scripts/main.js"></script>';
 $tools_back = ['href' => INVGEN_BASE . '/tools/', 'label' => 'All tools'];
 
-include __DIR__ . '/../invoice-generator/layout.php';
+include __DIR__ . '/../shared/layout.php';

--- a/free-receipt-scanner/index.php
+++ b/free-receipt-scanner/index.php
@@ -5,7 +5,7 @@
 // cards). Mirrors the desktop scanner's review UI; funnels to the free app +
 // Premium at the daily limit.
 
-require_once __DIR__ . '/../invoice-generator/_base.php'; // defines INVGEN_BASE
+require_once __DIR__ . '/../shared/_base.php'; // defines INVGEN_BASE
 
 if (PHP_SAPI !== 'cli') {
     require_once __DIR__ . '/../statistics.php'; // self-loads db_connect.php

--- a/guides/index.php
+++ b/guides/index.php
@@ -12,7 +12,7 @@
 //   no H2s on the index entries themselves (each list item is a link, not
 //   a section). Group dividers carry small-caps labels but no headings.
 
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 
 if (PHP_SAPI !== 'cli') {
     // Referral tracking: capture ?source so a direct landing on the guides hub
@@ -226,4 +226,4 @@ ob_start();
 <?php
 $body_content = ob_get_clean();
 
-include __DIR__ . '/../invoice-generator/layout.php';
+include __DIR__ . '/../shared/layout.php';

--- a/invoice-generator/_fragment.php
+++ b/invoice-generator/_fragment.php
@@ -15,7 +15,7 @@
 //   That value goes into the ?source= query param, which track_referral.php
 //   reads on the destination (argorobots.com/) to attribute the visit.
 //   Falls back to 'invgen-tool' when callers forget to set it.
-require_once __DIR__ . '/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 require_once __DIR__ . '/doc-config.php';
 // Document-type config drives copy, accessibility labels, conversion-CTA
 // attribution, and which invoice-only fields render. Defaults to 'invoice'

--- a/invoice-generator/index.php
+++ b/invoice-generator/index.php
@@ -39,8 +39,8 @@ ob_start();
 include __DIR__ . '/_fragment.php';
 $body_content = ob_get_clean();
 
-require_once __DIR__ . '/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 $extra_scripts = '<script type="module" src="' . INVGEN_BASE . '/invoice-generator/scripts/main.js"></script>';
 $tools_back = ['href' => INVGEN_BASE . '/tools/', 'label' => 'All tools'];
 
-include __DIR__ . '/layout.php';
+include __DIR__ . '/../shared/layout.php';

--- a/invoice-generator/styles/tool.css
+++ b/invoice-generator/styles/tool.css
@@ -1259,9 +1259,39 @@ body {
   max-width: 180px;
 }
 
+/* Editorial section nav on guide pages. Content links only (no pricing/CTA)
+   so the header reads as a blog section, not a sales funnel. */
+.site-header-nav {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex: 0 0 auto;
+}
+
+.site-header-nav a {
+  text-decoration: none;
+  color: var(--tool-text);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.site-header-nav a:hover,
+.site-header-nav a:focus {
+  color: var(--tool-primary);
+}
+
 @media (max-width: 540px) {
   .site-header-inner {
     padding: 12px 16px;
+    gap: 12px;
+  }
+
+  .site-header-nav {
+    gap: 16px;
+  }
+
+  .site-header-nav a {
+    font-size: 14px;
   }
 
   .tool-breadcrumb {

--- a/invoice-template/index.php
+++ b/invoice-template/index.php
@@ -5,7 +5,7 @@
 // SoftwareApplication is NOT the right schema here (the page is a directory,
 // not a tool); use CollectionPage instead.
 
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 
 if (PHP_SAPI !== 'cli') {
     require_once __DIR__ . '/../statistics.php';
@@ -101,4 +101,4 @@ ob_start();
 $body_content = ob_get_clean();
 $tools_back = ['href' => INVGEN_BASE . '/tools/', 'label' => 'All tools'];
 
-include __DIR__ . '/../invoice-generator/layout.php';
+include __DIR__ . '/../shared/layout.php';

--- a/invoice-template/template-page.php
+++ b/invoice-template/template-page.php
@@ -15,7 +15,7 @@
 //   <h2>     Frequently asked questions
 //   <h2>     Related templates
 
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 
 // --- 1. Sanitize the slug -----------------------------------------------------
 
@@ -279,7 +279,7 @@ document.addEventListener('DOMContentLoaded', function () {
 </script>
 HTML;
 
-include __DIR__ . '/../invoice-generator/layout.php';
+include __DIR__ . '/../shared/layout.php';
 
 // -----------------------------------------------------------------------------
 

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -1348,3 +1348,32 @@ INSERT IGNORE INTO reddit_keywords (keyword, notes) VALUES
     ('mileage tracking app', 'expense tracking for self-employed'),
     ('contractor invoicing app', 'trades invoicing'),
     ('profit and loss small business', 'bookkeeping reporting need');
+
+-- Per-call timing of desktop AI operations (receipt scan, bank categorize, supplier
+-- suggestion, spreadsheet analysis/processing via /api/ai/completions.php, and bank
+-- PDF extraction via /api/bank/extract.php). elapsed_ms is the SERVER-measured Gemini
+-- wall time, isolated from the user's network. The desktop app fetches aggregated
+-- p50/p90 priors from /api/ai/timing-priors.php to drive accurate, smooth progress
+-- bars. No user/device identity is stored (not needed for duration priors). Also
+-- created lazily by api/ai/_timing.php so a fresh server works without a migration.
+CREATE TABLE IF NOT EXISTS ai_call_timings (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    operation VARCHAR(40) NOT NULL COMMENT 'receipt_scan, bank_categorize, supplier_category, spreadsheet_analysis, spreadsheet_process, bank_pdf_extract, completion',
+    model VARCHAR(50) NOT NULL,
+    size_feature INT DEFAULT NULL COMMENT 'Op-specific size hint: image bytes, line count, column count, pdf bytes',
+    page_count INT DEFAULT NULL COMMENT 'PDFs only',
+    input_bytes INT DEFAULT NULL,
+    mime VARCHAR(30) DEFAULT NULL,
+    prompt_tokens INT DEFAULT NULL,
+    output_tokens INT DEFAULT NULL,
+    max_output_tokens INT DEFAULT NULL,
+    finish_reason VARCHAR(20) DEFAULT NULL COMMENT 'Non-STOP rows are excluded from priors',
+    elapsed_ms INT NOT NULL COMMENT 'Server-measured Gemini generate wall time',
+    poll_count INT DEFAULT NULL COMMENT 'PDF Files-API polls until ACTIVE',
+    success TINYINT(1) NOT NULL DEFAULT 1,
+    app_platform VARCHAR(20) DEFAULT NULL,
+    environment ENUM('production','sandbox') NOT NULL DEFAULT 'production',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_op_model_created (operation, model, created_at),
+    INDEX idx_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/niches/niche-page.php
+++ b/niches/niche-page.php
@@ -28,7 +28,7 @@
 // _base.php defines INVGEN_BASE and the shared invgen_render_404() helper
 // that niche_render_404() at the bottom of this file delegates to. Must be
 // required BEFORE the 404 fallbacks fire below.
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 
 // --- 1. Sanitize the slug -----------------------------------------------------
 
@@ -180,7 +180,7 @@ if (function_exists('current_environment')) {
 // hrefs. On Laragon the prefix is '/argo-books-website', on production
 // it is empty. Required again later for script paths (require_once
 // makes the second call a no-op).
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 
 ob_start();
 ?>
@@ -340,7 +340,7 @@ if (!empty($data['generator_defaults'])) {
     . json_encode($data['generator_defaults'], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP)
     . ';</script>';
 }
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 $extra_scripts .= '<script type="module" src="' . INVGEN_BASE . '/invoice-generator/scripts/main.js"></script>';
 
 // Collapsible FAQ click handler. One open at a time, matching the main
@@ -370,7 +370,7 @@ document.addEventListener('DOMContentLoaded', function () {
 </script>
 HTML;
 
-include __DIR__ . '/../invoice-generator/layout.php';
+include __DIR__ . '/../shared/layout.php';
 
 // -----------------------------------------------------------------------------
 

--- a/profit-analyzer/for-accountants/index.php
+++ b/profit-analyzer/for-accountants/index.php
@@ -4,7 +4,7 @@
 // tidy, multi-sheet workbook. Same engine as the owner tool, different emphasis.
 // CTA uses the referral-channel framing (recommend Argo to clients).
 
-require_once __DIR__ . '/../../invoice-generator/_base.php';
+require_once __DIR__ . '/../../shared/_base.php';
 
 if (PHP_SAPI !== 'cli') {
     require_once __DIR__ . '/../../statistics.php';

--- a/profit-analyzer/index.php
+++ b/profit-analyzer/index.php
@@ -4,7 +4,7 @@
 // Tool-isolated (own CSS, no main site header/footer): a focused, one-way
 // conversion funnel into Argo Books, matching the approved design mockup.
 
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 
 if (PHP_SAPI !== 'cli') {
     require_once __DIR__ . '/../statistics.php';

--- a/profit-analyzer/legal/privacy.php
+++ b/profit-analyzer/legal/privacy.php
@@ -1,6 +1,6 @@
 <?php
 // profit-analyzer/legal/privacy.php — Profit Analyzer data & privacy policy.
-require_once __DIR__ . '/../../invoice-generator/_base.php';
+require_once __DIR__ . '/../../shared/_base.php';
 if (PHP_SAPI !== 'cli') {
     require_once __DIR__ . '/../../statistics.php';
     track_page_view('profit_analyzer_privacy');

--- a/profit-analyzer/legal/terms.php
+++ b/profit-analyzer/legal/terms.php
@@ -1,6 +1,6 @@
 <?php
 // profit-analyzer/legal/terms.php — Profit Analyzer terms of use.
-require_once __DIR__ . '/../../invoice-generator/_base.php';
+require_once __DIR__ . '/../../shared/_base.php';
 if (PHP_SAPI !== 'cli') {
     require_once __DIR__ . '/../../statistics.php';
     track_page_view('profit_analyzer_terms');

--- a/profit-analyzer/results/index.php
+++ b/profit-analyzer/results/index.php
@@ -3,7 +3,7 @@
 // Post-upload result page: the full analytics view (sample data for now;
 // the real build feeds NormalizedData into the same markup + charts).
 
-require_once __DIR__ . '/../../invoice-generator/_base.php';
+require_once __DIR__ . '/../../shared/_base.php';
 
 if (PHP_SAPI !== 'cli') {
     require_once __DIR__ . '/../../statistics.php';

--- a/purchase-order-generator/index.php
+++ b/purchase-order-generator/index.php
@@ -8,7 +8,7 @@
 // and defers to the same layout.php + main.js. See invoice-generator/doc-config.php
 // for the full config and the consolidation rationale.
 
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 require_once __DIR__ . '/../invoice-generator/doc-config.php';
 
 $doc_type = 'purchase-order';
@@ -57,4 +57,4 @@ $body_content = ob_get_clean();
 $extra_scripts = '<script type="module" src="' . INVGEN_BASE . '/invoice-generator/scripts/main.js"></script>';
 $tools_back = ['href' => INVGEN_BASE . '/tools/', 'label' => 'All tools'];
 
-include __DIR__ . '/../invoice-generator/layout.php';
+include __DIR__ . '/../shared/layout.php';

--- a/self-employed-tax-calculator/index.php
+++ b/self-employed-tax-calculator/index.php
@@ -2,11 +2,11 @@
 // self-employed-tax-calculator/index.php
 // Standalone free self-employed tax calculator (US + Canada, 2026).
 //
-// Reuses the shared tool shell (invoice-generator/layout.php): same header,
+// Reuses the shared tool shell (shared/layout.php): same header,
 // "All tools" breadcrumb, SEO/OG/schema, and tool.css chrome. The calculation
 // is client-side (scripts/main.js + calc.js + data/tax-rates-2026.js).
 
-require_once __DIR__ . '/../invoice-generator/_base.php';
+require_once __DIR__ . '/../shared/_base.php';
 
 if (PHP_SAPI !== 'cli') {
     require_once __DIR__ . '/../statistics.php';
@@ -126,4 +126,4 @@ ob_start();
 <?php
 $body_content = ob_get_clean();
 
-include __DIR__ . '/../invoice-generator/layout.php';
+include __DIR__ . '/../shared/layout.php';

--- a/shared/_base.php
+++ b/shared/_base.php
@@ -1,5 +1,5 @@
 <?php
-// invoice-generator/_base.php
+// shared/_base.php
 // Auto-detected URL prefix that maps to this project's root.
 //
 // In production at argorobots.com (DocumentRoot is the project root): ''.

--- a/shared/layout.php
+++ b/shared/layout.php
@@ -1,8 +1,9 @@
 <?php
-// invoice-generator/layout.php
-// Minimal tool-isolated layout. Used by tool pages only.
-// Do NOT include the main site's header, footer, or main.js.
-// One-way funnel: tool pages link out to argorobots.com, never the reverse.
+// shared/layout.php
+// Minimal self-contained page shell shared across the standalone tools
+// (invoice-generator, profit-analyzer, etc.), the guides/articles, and the
+// niche pages. Does NOT include the main site's header, footer, or main.js;
+// these pages link out to argorobots.com rather than pulling its chrome in.
 
 require_once __DIR__ . '/_base.php';
 
@@ -96,6 +97,13 @@ $site_schema = [
     <a class="site-brand" href="<?= INVGEN_BASE ?>/" aria-label="Argo Books home">
       <img src="<?= INVGEN_BASE ?>/resources/images/argo-logo/argo-logo-black.png" alt="Argo Books" width="160" height="28">
     </a>
+    <?php if (!empty($header_nav)): ?>
+    <nav class="site-header-nav" aria-label="Section navigation">
+      <?php foreach ($header_nav as $nav_item): ?>
+      <a href="<?= INVGEN_BASE ?>/<?= ltrim(htmlspecialchars($nav_item['href']), '/') ?>"><?= htmlspecialchars($nav_item['label']) ?></a>
+      <?php endforeach; ?>
+    </nav>
+    <?php endif; ?>
   </div>
 </header>
 <?php if ($tools_back): ?>


### PR DESCRIPTION
## Summary

Server-side support for the desktop app's accurate loading bars, plus two unrelated content/layout changes that landed on this branch.

### AI operation timing & duration priors (primary)
The desktop app's progress bars estimate how long an opaque AI call will take from **pooled, server-measured timings** rather than guessing locally. This adds the server half:

- **`ai_call_timings` table** (`mysql_schema.sql`): records each AI call's operation, size feature, and measured duration.
- **`/api/ai/completions.php`** and **`/api/bank/extract.php`**: time the upstream call (and capture page/poll counts for PDF extraction) and record a timing row per call.
- **`/api/ai/timing-priors.php`** (new endpoint): serves per-operation p50/p90 duration priors computed from the pooled data, which the app fetches at startup to seed its estimates.
- Shared timing helpers in **`/api/ai/_timing.php`**.

This is the companion to the app-side `feat/loading-progress-client` work (merged into `V.2.0.9`); the app falls back to bundled seed priors until this is deployed.

### QuickBooks Desktop discontinued guide
A new content/SEO guide covering the QuickBooks Desktop discontinuation.

### Shared tool/guide shell refactor
Moved the shared page shell (`_base.php`, `layout.php`) out of `invoice-generator/` into a top-level `shared/` directory and pointed all the tool/guide pages (estimate generator, profit analyzer, invoice templates, niche pages, etc.) at it, so the shared layout isn't owned by one tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
