### PR TITLE
Outreach discovery overhaul: pagination, target-count loop, and Partners channel

### DIFF
--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -163,6 +163,12 @@ switch ($action) {
     case 'creator_add_url':
         creator_add_url($pdo);
         break;
+    case 'creator_export_emailless':
+        creator_export_emailless($pdo);
+        break;
+    case 'creator_set_email':
+        creator_set_email($pdo);
+        break;
 
     // AI draft
     case 'generate_draft':
@@ -1776,6 +1782,76 @@ function creator_import($pdo)
         outreach_log("Creator import failed: " . $e->getMessage());
         json_response(['success' => false, 'message' => 'Database error: ' . $e->getMessage()], 500);
     }
+}
+
+// Export creator leads that still have no email, as the input file for the local
+// assisted-captcha helper (tools/youtube-email-assist). Shape: [{lead_id, name, url}].
+function creator_export_emailless($pdo)
+{
+    $stmt = $pdo->query("SELECT id, business_name, website FROM outreach_leads
+        WHERE source = 'creator_auto' AND (email IS NULL OR email = '')
+        ORDER BY date_added DESC");
+    $rows = $stmt->fetchAll();
+    $out = [];
+    foreach ($rows as $r) {
+        $out[] = ['lead_id' => (int) $r['id'], 'name' => $r['business_name'], 'url' => $r['website']];
+    }
+    json_response(['success' => true, 'count' => count($out), 'leads' => $out]);
+}
+
+// Apply emails captured by the assisted helper back onto creator leads. Accepts
+// either a single {lead_id, email} or {results: [{lead_id, url, email}, ...]}.
+function creator_set_email($pdo)
+{
+    $data = json_decode(file_get_contents('php://input'), true) ?: [];
+    if (is_array($data) && array_is_list($data)) {
+        // Raw top-level array (the helper's output.json posted directly).
+        $results = $data;
+    } else {
+        $results = $data['results'] ?? null;
+        if (!is_array($results)) {
+            // Single-item form.
+            if (isset($data['email'])) {
+                $results = [['lead_id' => $data['lead_id'] ?? null, 'url' => $data['url'] ?? null, 'email' => $data['email']]];
+            } else {
+                json_response(['success' => false, 'message' => 'Provide results[] or a single {lead_id/url, email}'], 400);
+            }
+        }
+    }
+
+    $updated = 0;
+    $skipped = 0;
+    foreach ($results as $row) {
+        $email = trim((string) ($row['email'] ?? ''));
+        if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) { $skipped++; continue; }
+
+        $leadId = (int) ($row['lead_id'] ?? 0);
+        $url    = trim((string) ($row['url'] ?? ''));
+
+        if ($leadId > 0) {
+            $stmt = $pdo->prepare("UPDATE outreach_leads SET email = ? WHERE id = ? AND source = 'creator_auto' AND (email IS NULL OR email = '')");
+            $stmt->execute([$email, $leadId]);
+        } elseif ($url !== '') {
+            $stmt = $pdo->prepare("UPDATE outreach_leads SET email = ? WHERE website = ? AND source = 'creator_auto' AND (email IS NULL OR email = '')");
+            $stmt->execute([$email, $url]);
+        } else {
+            $skipped++;
+            continue;
+        }
+
+        if ($stmt->rowCount() > 0) {
+            $updated++;
+            // Mirror onto the candidate row's harvested_email where we can match it.
+            if ($url !== '') {
+                $c = $pdo->prepare("UPDATE outreach_creator_candidates SET harvested_email = ? WHERE canonical_url = ?");
+                $c->execute([$email, $url]);
+            }
+        } else {
+            $skipped++;
+        }
+    }
+
+    json_response(['success' => true, 'updated' => $updated, 'skipped' => $skipped]);
 }
 
 // ─── AI Draft Generation ───

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -766,12 +766,27 @@ function shopify_run_dork($pdo)
     // keep hitting the same query.
     $cursor               = (int) _shopify_state_get($pdo, 'shopify_dork_cursor', '0');
     $poolSize             = count(SHOPIFY_DORK_POOL);
+    $pages                = json_decode(_shopify_state_get($pdo, 'shopify_dork_pages', '{}'), true);
+    if (!is_array($pages)) {
+        $pages = [];
+    }
     $fits                 = [];
     $rejectedCount        = 0;
     $rejectReasons        = [];
     $alreadyImportedCount = 0;
     $totalEvaluated       = 0;
     $queriesRun           = [];
+
+    // Per-run guardrails (mirror the editorial channel): a SerpAPI-call budget so
+    // one Run can't drain the daily quota, a page-depth cap per dork, and a
+    // dry-streak exit so we stop once the whole pool stops yielding new stores.
+    $serpCallsThisRun = 0;
+    $perRunSerpBudget = max(1, (int) ($_ENV['SERPAPI_MAX_CALLS_PER_RUN'] ?? 12));
+    $maxPageDepth     = max(1, (int) ($_ENV['SHOPIFY_MAX_PAGE_DEPTH'] ?? 3));
+    $pageSize         = 100;
+    $maxStart         = ($maxPageDepth - 1) * $pageSize;
+    $dryQueries       = 0;
+    $stopReason       = 'target_reached';
 
     // Within-run dedup. The same store surfaces across multiple dork queries
     // (and via different deep links that all canonicalize to one origin), so
@@ -785,25 +800,44 @@ function shopify_run_dork($pdo)
     $seenCanonicals = [];
     $seenIdentities = [];
 
-    while (count($fits) < $limit && $callsToday < $serpapiLimit) {
-        $query = SHOPIFY_DORK_POOL[$cursor % $poolSize];
+    while (true) {
+        if (count($fits) >= $limit)                 { $stopReason = 'target_reached'; break; }
+        if ($callsToday >= $serpapiLimit)           { $stopReason = 'daily_quota';    break; }
+        if ($serpCallsThisRun >= $perRunSerpBudget) { $stopReason = 'run_budget';     break; }
+        if ($dryQueries >= $poolSize)               { $stopReason = 'exhausted';      break; }
+
+        $idx   = $cursor % $poolSize;
+        $query = SHOPIFY_DORK_POOL[$idx];
         $cursor++;
         _shopify_state_set($pdo, 'shopify_dork_cursor', (string) $cursor);
 
+        $start = (int) ($pages[(string) $idx] ?? 0);
+        if ($start > $maxStart) {
+            $dryQueries++;
+            continue;
+        }
+
         $queryWithExclusions = $query . SHOPIFY_DORK_EXCLUSIONS;
-        $queryResult = serpapi_query_cached($queryWithExclusions, $apiKey, 100, $pdo);
+        $queryResult = serpapi_query_cached($queryWithExclusions, $apiKey, $pageSize, $pdo, $start);
         $serpResults = $queryResult['results'];
         if (!$queryResult['from_cache']) {
             $callsToday++;
+            $serpCallsThisRun++;
             _shopify_state_set($pdo, 'serpapi_calls_today', (string) $callsToday);
         }
-        $queriesRun[] = $query;
+        $pages[(string) $idx] = $start + $pageSize;
+        _shopify_state_set($pdo, 'shopify_dork_pages', json_encode($pages));
+        $queriesRun[] = $query . ' (p' . (intdiv($start, $pageSize) + 1) . ')';
 
-        if (empty($serpResults)) continue;
+        if (empty($serpResults)) {
+            $dryQueries++;
+            continue;
+        }
         $totalEvaluated += count($serpResults);
 
+        $foundNew = false;
         foreach ($serpResults as $r) {
-            if (count($fits) >= $limit) break 2;
+            if (count($fits) >= $limit) break;
 
             $canonical = shopify_canonical_url($r['link'] ?? '');
             if ($canonical === '') continue;
@@ -827,6 +861,7 @@ function shopify_run_dork($pdo)
                 continue;
             }
 
+            $foundNew = true;
             $result = evaluate_shopify_candidate($canonical);
 
             if (empty($result['fit'])) {
@@ -861,6 +896,12 @@ function shopify_run_dork($pdo)
                 'country'          => $meta['country'] ?? '',
             ];
         }
+
+        if ($foundNew) {
+            $dryQueries = 0;
+        } else {
+            $dryQueries++;
+        }
     }
 
     $quotaExhausted = $callsToday >= $serpapiLimit && count($fits) < $limit;
@@ -869,12 +910,15 @@ function shopify_run_dork($pdo)
         'success'                => true,
         'results'                => $fits,
         'requested_limit'        => $limit,
+        'found_count'            => count($fits),
+        'stop_reason'            => $stopReason,
         'quota_exhausted'        => $quotaExhausted,
         'rejected_count'         => $rejectedCount,
         'reject_reasons'         => $rejectReasons,
         'already_imported_count' => $alreadyImportedCount,
         'total_evaluated'        => $totalEvaluated,
         'queries_run'            => $queriesRun,
+        'serpapi_calls_this_run' => $serpCallsThisRun,
         'serpapi_calls_today'    => $callsToday,
         'serpapi_limit'          => $serpapiLimit,
         'imports_today'          => (int) _shopify_state_get($pdo, 'shopify_imports_today', '0'),
@@ -1037,6 +1081,11 @@ function editorial_run_discovery($pdo)
 
     $cursor               = (int) _shopify_state_get($pdo, 'editorial_query_cursor', '0');
     $poolSize             = count(EDITORIAL_QUERY_POOL);
+    $pages                = json_decode(_shopify_state_get($pdo, 'editorial_pages', '{}'), true);
+    if (!is_array($pages)) {
+        $pages = [];
+    }
+
     $fits                 = [];
     $rejectedCount        = 0;
     $rejectReasons        = [];
@@ -1045,40 +1094,74 @@ function editorial_run_discovery($pdo)
     $totalEvaluated       = 0;
     $queriesRun           = [];
     $seen                 = [];
-    // Bound the expensive work per run so the request can't time out: each
-    // evaluation does a live page fetch + a Gemini call (+ a contact-page scrape
-    // for fits), which is slow and variable. Cap the number of evaluations and
-    // the total wall-clock, and persist rejects so repeated Run clicks make
-    // progress (skipping already-handled articles) instead of re-doing them.
-    $evaluated = 0;
-    $maxEval   = 15;
-    $deadline  = microtime(true) + 35;
 
-    while (count($fits) < $limit && $callsToday < $serpapiLimit && $evaluated < $maxEval && microtime(true) < $deadline) {
-        $query = EDITORIAL_QUERY_POOL[$cursor % $poolSize];
+    // Target-count loop: keep pulling deeper result pages and rotating queries
+    // until we've collected $limit NEW fits, bounded by guardrails so a run can't
+    // time out or run up the SerpAPI/AI bill. Everything that makes this resumable
+    // is persisted (query cursor + per-query page offset), so clicking Run again
+    // continues from where this left off instead of re-scanning page 1.
+    $evaluated        = 0;
+    $serpCallsThisRun = 0;
+    $maxEval          = max(1, (int) ($_ENV['EDITORIAL_MAX_EVAL_PER_RUN'] ?? 20));   // Gemini/scrape ceiling per run
+    $perRunSerpBudget = max(1, (int) ($_ENV['SERPAPI_MAX_CALLS_PER_RUN'] ?? 12));    // SerpAPI calls per run
+    $maxPageDepth     = max(1, (int) ($_ENV['EDITORIAL_MAX_PAGE_DEPTH'] ?? 6));      // how deep per query before it's "tapped out"
+    $pageSize         = 15;
+    $maxStart         = ($maxPageDepth - 1) * $pageSize;
+    $deadline         = microtime(true) + 50;
+    $dryQueries       = 0;   // consecutive queries that yielded no NEW candidate
+    $stopReason       = 'target_reached';
+
+    while (true) {
+        if (count($fits) >= $limit)                 { $stopReason = 'target_reached'; break; }
+        if ($callsToday >= $serpapiLimit)           { $stopReason = 'daily_quota';    break; }
+        if ($serpCallsThisRun >= $perRunSerpBudget) { $stopReason = 'run_budget';     break; }
+        if ($evaluated >= $maxEval)                 { $stopReason = 'eval_cap';       break; }
+        if (microtime(true) >= $deadline)           { $stopReason = 'time';           break; }
+        if ($dryQueries >= $poolSize)               { $stopReason = 'exhausted';      break; }
+
+        $idx   = $cursor % $poolSize;
+        $query = EDITORIAL_QUERY_POOL[$idx];
         $cursor++;
         _shopify_state_set($pdo, 'editorial_query_cursor', (string) $cursor);
 
-        $searchResult = editorial_search($query, $apiKey, 15, $pdo);
+        $start = (int) ($pages[(string) $idx] ?? 0);
+        if ($start > $maxStart) {
+            // This query is tapped out to our page-depth cap; skip without a call.
+            $dryQueries++;
+            continue;
+        }
+
+        $searchResult = editorial_search($query, $apiKey, $pageSize, $pdo, $start);
         if (!$searchResult['from_cache']) {
             $callsToday++;
+            $serpCallsThisRun++;
             _shopify_state_set($pdo, 'serpapi_calls_today', (string) $callsToday);
         }
-        $queriesRun[] = $query;
+        // Advance this query's page offset so the next iteration/run goes deeper.
+        $pages[(string) $idx] = $start + $pageSize;
+        _shopify_state_set($pdo, 'editorial_pages', json_encode($pages));
+        $queriesRun[] = $query . ' (p' . (intdiv($start, $pageSize) + 1) . ')';
 
         $serpResults = $searchResult['results'];
-        if (empty($serpResults)) continue;
+        if (empty($serpResults)) {
+            $dryQueries++;
+            continue;
+        }
         $totalEvaluated += count($serpResults);
 
+        $foundNew = false;
         foreach ($serpResults as $r) {
-            if (count($fits) >= $limit || $evaluated >= $maxEval || microtime(true) >= $deadline) break 2;
+            if (count($fits) >= $limit || $evaluated >= $maxEval || microtime(true) >= $deadline) {
+                break;
+            }
 
             $canonical = $r['url'];
             if (isset($seen[$canonical])) continue;
             $seen[$canonical] = true;
 
-            // Skip articles already imported or recently rejected, so repeated
-            // runs advance to new candidates instead of re-evaluating the same ones.
+            // Pre-dedup BEFORE spending any AI: skip already-imported or recently
+            // rejected articles so we never pay Gemini/Hunter to re-evaluate a
+            // candidate we've already handled.
             $existing = $pdo->prepare("SELECT status FROM outreach_editorial_candidates
                 WHERE canonical_url = ?
                   AND (status = 'imported'
@@ -1095,6 +1178,7 @@ function editorial_run_discovery($pdo)
                 continue;
             }
 
+            $foundNew = true;
             $evaluated++;
             try {
                 $result = evaluate_editorial_candidate($canonical, $pdo, $r['title'] ?? '');
@@ -1136,6 +1220,14 @@ function editorial_run_discovery($pdo)
                 'business_summary' => $meta['business_summary'] ?? '',
             ];
         }
+
+        // A query that surfaced no new candidate counts toward exhaustion; one
+        // that did resets the dry streak so we keep mining productive queries.
+        if ($foundNew) {
+            $dryQueries = 0;
+        } else {
+            $dryQueries++;
+        }
     }
 
     $quotaExhausted = $callsToday >= $serpapiLimit && count($fits) < $limit;
@@ -1144,6 +1236,8 @@ function editorial_run_discovery($pdo)
         'success'                => true,
         'results'                => $fits,
         'requested_limit'        => $limit,
+        'found_count'            => count($fits),
+        'stop_reason'            => $stopReason,
         'quota_exhausted'        => $quotaExhausted,
         'rejected_count'         => $rejectedCount,
         'reject_reasons'         => $rejectReasons,
@@ -1151,6 +1245,7 @@ function editorial_run_discovery($pdo)
         'already_rejected_count' => $alreadyRejectedCount,
         'total_evaluated'        => $totalEvaluated,
         'queries_run'            => $queriesRun,
+        'serpapi_calls_this_run' => $serpCallsThisRun,
         'serpapi_calls_today'    => $callsToday,
         'serpapi_limit'          => $serpapiLimit,
     ]);

--- a/admin/outreach/api.php
+++ b/admin/outreach/api.php
@@ -64,7 +64,7 @@ function is_pipeline_running(): bool
 $action = $_GET['action'] ?? $_POST['action'] ?? '';
 
 // Block actions that conflict with a running pipeline
-$pipelineActions = ['send_email', 'generate_draft', 'import_leads', 'search_businesses', 'regenerate_followup', 'shopify_run_dork', 'shopify_import', 'editorial_run_discovery', 'editorial_import', 'editorial_add_url'];
+$pipelineActions = ['send_email', 'generate_draft', 'import_leads', 'search_businesses', 'regenerate_followup', 'shopify_run_dork', 'shopify_import', 'editorial_run_discovery', 'editorial_import', 'editorial_add_url', 'creator_run_discovery', 'creator_import', 'creator_add_url'];
 if (in_array($action, $pipelineActions) && is_pipeline_running()) {
     echo json_encode([
         'success' => false,
@@ -148,6 +148,20 @@ switch ($action) {
         break;
     case 'editorial_add_url':
         editorial_add_url($pdo);
+        break;
+
+    // Creators / affiliate-partner discovery
+    case 'creator_get_status':
+        creator_get_status($pdo);
+        break;
+    case 'creator_run_discovery':
+        creator_run_discovery($pdo);
+        break;
+    case 'creator_import':
+        creator_import($pdo);
+        break;
+    case 'creator_add_url':
+        creator_add_url($pdo);
         break;
 
     // AI draft
@@ -317,10 +331,10 @@ function get_leads($pdo)
             $params[] = $source;
         }
     } else {
-        // Editorial leads have their own channel tab (source=editorial_auto is
-        // requested explicitly there). Keep them out of the default Email leads
-        // list so the two channels stay organized and separate.
-        $where[] = "ol.source != 'editorial_auto'";
+        // Editorial and Creator leads have their own channel tabs (their source
+        // is requested explicitly there). Keep them out of the default Email
+        // leads list so the channels stay organized and separate.
+        $where[] = "ol.source NOT IN ('editorial_auto', 'creator_auto')";
     }
     if ($search) {
         $where[] = '(ol.business_name LIKE ? OR ol.email LIKE ? OR ol.contact_name LIKE ? OR ol.city LIKE ? OR ol.category LIKE ?)';
@@ -1394,6 +1408,372 @@ function editorial_import($pdo)
         json_response(['success' => true, 'lead_id' => $leadId]);
     } catch (Exception $e) {
         outreach_log("Editorial import failed: " . $e->getMessage());
+        json_response(['success' => false, 'message' => 'Database error: ' . $e->getMessage()], 500);
+    }
+}
+
+// ─── Creators / affiliate-partner discovery ───
+// Finds YouTubers, newsletter writers, and niche bloggers whose audience is small
+// businesses / freelancers, so we can recruit them as affiliate partners. Mirrors
+// the editorial handlers (paginated, resumable target-count loop) but with the
+// affiliate pitch. Shares the SerpAPI daily budget with the other channels.
+
+function creator_get_status($pdo)
+{
+    _shopify_reset_daily_counters_if_needed($pdo);
+    json_response([
+        'success'             => true,
+        'enabled'             => ($_ENV['OUTREACH_CREATOR_ENABLED'] ?? 'false') === 'true',
+        'has_key'             => !empty($_ENV['SERPAPI_KEY']),
+        'has_hunter'          => !empty($_ENV['HUNTER_API_KEY']),
+        'serpapi_calls_today' => (int) _shopify_state_get($pdo, 'serpapi_calls_today', '0'),
+        'serpapi_limit'       => (int) ($_ENV['SERPAPI_DAILY_QUERY_LIMIT'] ?? 3),
+    ]);
+}
+
+function creator_run_discovery($pdo)
+{
+    require_once __DIR__ . '/../../cron/lib/creator_discovery.php';
+    @set_time_limit(300);
+
+    $data  = json_decode(file_get_contents('php://input'), true) ?: [];
+    $limit = min(30, max(1, (int) ($data['limit'] ?? 8)));
+
+    $apiKey = $_ENV['SERPAPI_KEY'] ?? '';
+    if ($apiKey === '') {
+        json_response(['success' => false, 'message' => 'SerpAPI key not configured. Set SERPAPI_KEY in .env'], 500);
+    }
+
+    _shopify_reset_daily_counters_if_needed($pdo);
+    $serpapiLimit = (int) ($_ENV['SERPAPI_DAILY_QUERY_LIMIT'] ?? 3);
+    $callsToday   = (int) _shopify_state_get($pdo, 'serpapi_calls_today', '0');
+    if ($callsToday >= $serpapiLimit) {
+        json_response([
+            'success' => false,
+            'message' => "SerpAPI daily limit reached ($callsToday/$serpapiLimit). Resets at midnight or raise SERPAPI_DAILY_QUERY_LIMIT in .env.",
+        ], 429);
+    }
+
+    $cursor               = (int) _shopify_state_get($pdo, 'creator_query_cursor', '0');
+    $poolSize             = count(CREATOR_QUERY_POOL);
+    $pages                = json_decode(_shopify_state_get($pdo, 'creator_pages', '{}'), true);
+    if (!is_array($pages)) {
+        $pages = [];
+    }
+
+    $fits                 = [];
+    $rejectedCount        = 0;
+    $rejectReasons        = [];
+    $alreadyImportedCount = 0;
+    $alreadyRejectedCount = 0;
+    $totalEvaluated       = 0;
+    $queriesRun           = [];
+    $seen                 = [];
+
+    // Resumable target-count loop (same shape as the editorial channel): keep
+    // paging deeper and rotating queries until $limit NEW fits, bounded so a run
+    // can't time out or run up the SerpAPI/AI bill.
+    $evaluated        = 0;
+    $serpCallsThisRun = 0;
+    $maxEval          = max(1, (int) ($_ENV['CREATOR_MAX_EVAL_PER_RUN'] ?? 20));
+    $perRunSerpBudget = max(1, (int) ($_ENV['SERPAPI_MAX_CALLS_PER_RUN'] ?? 12));
+    $maxPageDepth     = max(1, (int) ($_ENV['CREATOR_MAX_PAGE_DEPTH'] ?? 6));
+    $pageSize         = 15;
+    $maxStart         = ($maxPageDepth - 1) * $pageSize;
+    $deadline         = microtime(true) + 50;
+    $dryQueries       = 0;
+    $stopReason       = 'target_reached';
+
+    while (true) {
+        if (count($fits) >= $limit)                 { $stopReason = 'target_reached'; break; }
+        if ($callsToday >= $serpapiLimit)           { $stopReason = 'daily_quota';    break; }
+        if ($serpCallsThisRun >= $perRunSerpBudget) { $stopReason = 'run_budget';     break; }
+        if ($evaluated >= $maxEval)                 { $stopReason = 'eval_cap';       break; }
+        if (microtime(true) >= $deadline)           { $stopReason = 'time';           break; }
+        if ($dryQueries >= $poolSize)               { $stopReason = 'exhausted';      break; }
+
+        $idx   = $cursor % $poolSize;
+        $query = CREATOR_QUERY_POOL[$idx];
+        $cursor++;
+        _shopify_state_set($pdo, 'creator_query_cursor', (string) $cursor);
+
+        $start = (int) ($pages[(string) $idx] ?? 0);
+        if ($start > $maxStart) {
+            $dryQueries++;
+            continue;
+        }
+
+        $searchResult = creator_search($query, $apiKey, $pageSize, $pdo, $start);
+        if (!$searchResult['from_cache']) {
+            $callsToday++;
+            $serpCallsThisRun++;
+            _shopify_state_set($pdo, 'serpapi_calls_today', (string) $callsToday);
+        }
+        $pages[(string) $idx] = $start + $pageSize;
+        _shopify_state_set($pdo, 'creator_pages', json_encode($pages));
+        $queriesRun[] = $query . ' (p' . (intdiv($start, $pageSize) + 1) . ')';
+
+        $serpResults = $searchResult['results'];
+        if (empty($serpResults)) {
+            $dryQueries++;
+            continue;
+        }
+        $totalEvaluated += count($serpResults);
+
+        $foundNew = false;
+        foreach ($serpResults as $r) {
+            if (count($fits) >= $limit || $evaluated >= $maxEval || microtime(true) >= $deadline) {
+                break;
+            }
+
+            $canonical = $r['url'];
+            if (isset($seen[$canonical])) continue;
+            $seen[$canonical] = true;
+
+            // Pre-dedup before any AI spend.
+            $existing = $pdo->prepare("SELECT status FROM outreach_creator_candidates
+                WHERE canonical_url = ?
+                  AND (status = 'imported'
+                       OR (status = 'rejected' AND checked_at > DATE_SUB(NOW(), INTERVAL 14 DAY)))
+                LIMIT 1");
+            $existing->execute([$canonical]);
+            $existingStatus = $existing->fetchColumn();
+            if ($existingStatus !== false) {
+                if ($existingStatus === 'imported') {
+                    $alreadyImportedCount++;
+                } else {
+                    $alreadyRejectedCount++;
+                }
+                continue;
+            }
+
+            $foundNew = true;
+            $evaluated++;
+            try {
+                $result = evaluate_creator_candidate($canonical, $pdo, $r['title'] ?? '');
+            } catch (Throwable $e) {
+                outreach_log("Creator evaluate error for $canonical: " . $e->getMessage());
+                $result = ['fit' => false, 'reason' => 'eval_error', 'detail' => $e->getMessage()];
+            }
+
+            if (empty($result['fit'])) {
+                $rejectedCount++;
+                $reason = $result['reason'] ?? 'unknown';
+                $rejectReasons[$reason] = ($rejectReasons[$reason] ?? 0) + 1;
+                $up = $pdo->prepare("INSERT INTO outreach_creator_candidates
+                    (canonical_url, status, reject_reason, reject_detail, platform, last_query)
+                    VALUES (?, 'rejected', ?, ?, ?, ?)
+                    ON DUPLICATE KEY UPDATE status = 'rejected',
+                        reject_reason = VALUES(reject_reason),
+                        reject_detail = VALUES(reject_detail),
+                        checked_at = NOW()");
+                $up->execute([
+                    $canonical,
+                    mb_substr($reason, 0, 100),
+                    mb_substr((string) ($result['detail'] ?? ''), 0, 500),
+                    mb_substr((string) ($result['metadata']['platform'] ?? $r['platform'] ?? ''), 0, 20),
+                    mb_substr($query, 0, 255),
+                ]);
+                continue;
+            }
+
+            $meta = $result['metadata'] ?? [];
+            $fits[] = [
+                'canonical_url'    => $canonical,
+                'serp_title'       => $r['title'] ?? '',
+                'platform'         => $meta['platform'] ?? ($r['platform'] ?? ''),
+                'creator_name'     => $meta['creator_name'] ?? '',
+                'audience'         => $meta['audience'] ?? '',
+                'topics'           => implode(', ', array_slice($meta['topics'] ?? [], 0, 6)),
+                'email'            => $meta['email'] ?? '',
+                'email_source'     => $meta['email_source'] ?? '',
+                'needs_manual_email' => !empty($meta['needs_manual_email']),
+                'business_summary' => $meta['business_summary'] ?? '',
+            ];
+        }
+
+        if ($foundNew) {
+            $dryQueries = 0;
+        } else {
+            $dryQueries++;
+        }
+    }
+
+    $quotaExhausted = $callsToday >= $serpapiLimit && count($fits) < $limit;
+
+    json_response([
+        'success'                => true,
+        'results'                => $fits,
+        'requested_limit'        => $limit,
+        'found_count'            => count($fits),
+        'stop_reason'            => $stopReason,
+        'quota_exhausted'        => $quotaExhausted,
+        'rejected_count'         => $rejectedCount,
+        'reject_reasons'         => $rejectReasons,
+        'already_imported_count' => $alreadyImportedCount,
+        'already_rejected_count' => $alreadyRejectedCount,
+        'total_evaluated'        => $totalEvaluated,
+        'queries_run'            => $queriesRun,
+        'serpapi_calls_this_run' => $serpCallsThisRun,
+        'serpapi_calls_today'    => $callsToday,
+        'serpapi_limit'          => $serpapiLimit,
+    ]);
+}
+
+function creator_add_url($pdo)
+{
+    require_once __DIR__ . '/../../cron/lib/creator_discovery.php';
+    @set_time_limit(120);
+
+    $data = json_decode(file_get_contents('php://input'), true) ?: [];
+    $url  = trim($data['url'] ?? '');
+    if ($url !== '' && !preg_match('#^https?://#i', $url)) {
+        $url = 'https://' . $url;
+    }
+    if ($url === '' || !filter_var($url, FILTER_VALIDATE_URL)) {
+        json_response(['success' => false, 'message' => 'A valid creator URL is required'], 400);
+    }
+
+    $canonical = creator_canonical_url($url);
+
+    $check = $pdo->prepare("SELECT id FROM outreach_leads WHERE website = ? LIMIT 1");
+    $check->execute([$canonical]);
+    if ($existing = $check->fetchColumn()) {
+        json_response(['success' => false, 'message' => 'This creator is already a lead', 'existing_lead_id' => (int) $existing], 409);
+    }
+
+    // Forced evaluate: a hand-added URL is imported even if borderline or with no
+    // email found (common for YouTube). The operator can fill in the email later.
+    $meta = [];
+    try {
+        $result = evaluate_creator_candidate($canonical, $pdo, '', true);
+        $meta = $result['metadata'] ?? [];
+    } catch (Throwable $e) {
+        outreach_log("Creator add-url evaluate error for $canonical: " . $e->getMessage());
+    }
+
+    $platform = trim((string) ($meta['platform'] ?? creator_platform_from_url($canonical)));
+    $name     = trim((string) ($meta['creator_name'] ?? '')) ?: editorial_domain_from_url($canonical);
+    $email    = trim((string) ($meta['email'] ?? ''));
+    $summary  = trim((string) ($meta['business_summary'] ?? ''));
+    if ($summary === '') {
+        $summary = "Creator to recruit as an affiliate: {$canonical} (platform: {$platform}). Goal: recruit as an Argo Books affiliate partner.";
+    }
+
+    try {
+        $stmt = $pdo->prepare("INSERT INTO outreach_leads
+            (business_name, contact_name, email, website, source, contact_page_url, business_summary, category, country)
+            VALUES (?, ?, ?, ?, 'creator_auto', ?, ?, ?, 'US')");
+        $stmt->execute([
+            $name,
+            $name !== '' ? $name : null,
+            $email !== '' ? $email : null,
+            $canonical,
+            $canonical,
+            $summary,
+            'creator:' . $platform,
+        ]);
+        $leadId = (int) $pdo->lastInsertId();
+
+        $stmt = $pdo->prepare("INSERT INTO outreach_creator_candidates
+            (canonical_url, status, lead_id, platform, creator_name, harvested_email, last_query)
+            VALUES (?, 'imported', ?, ?, ?, ?, 'admin-url')
+            ON DUPLICATE KEY UPDATE status = 'imported', lead_id = VALUES(lead_id),
+                platform = VALUES(platform), creator_name = VALUES(creator_name),
+                harvested_email = VALUES(harvested_email)");
+        $stmt->execute([$canonical, $leadId, $platform, $name, $email]);
+
+        log_activity($pdo, $leadId, 'lead_created', 'Added by URL to the Creators channel');
+        json_response([
+            'success'   => true,
+            'lead_id'   => $leadId,
+            'platform'  => $platform,
+            'name'      => $name,
+            'email'     => $email,
+            'has_email' => $email !== '',
+        ]);
+    } catch (Exception $e) {
+        outreach_log("Creator add-url import failed: " . $e->getMessage());
+        json_response(['success' => false, 'message' => 'Database error: ' . $e->getMessage()], 500);
+    }
+}
+
+function creator_import($pdo)
+{
+    $data         = json_decode(file_get_contents('php://input'), true) ?: [];
+    $canonicalUrl = trim($data['canonical_url'] ?? '');
+    $email        = trim($data['email'] ?? '');
+    $platform     = trim($data['platform'] ?? '');
+    $name         = trim($data['creator_name'] ?? '');
+    $summary      = trim($data['business_summary'] ?? '');
+
+    // Import from the discovery-computed data (no re-evaluate). Unlike editorial,
+    // an email is NOT required: many creators (especially YouTubers) have no
+    // auto-harvestable email and are worked manually or via the assisted helper.
+    if ($canonicalUrl === '') {
+        json_response(['success' => false, 'message' => 'canonical_url is required'], 400);
+    }
+    if ($email !== '' && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        json_response(['success' => false, 'message' => 'The provided email is not valid'], 400);
+    }
+    if ($platform === '') {
+        require_once __DIR__ . '/../../cron/lib/creator_discovery.php';
+        $platform = creator_platform_from_url($canonicalUrl);
+    }
+    if ($name === '') {
+        $name = $canonicalUrl;
+    }
+    if ($summary === '') {
+        $summary = 'Creator to recruit as an affiliate' . ($platform !== '' ? " (platform: {$platform})" : '') . '. Goal: recruit as an Argo Books affiliate partner.';
+    }
+
+    // Dedup by canonical URL always, and by email only when one was provided
+    // (empty email must not collide with other email-less creator leads).
+    if ($email !== '') {
+        $check = $pdo->prepare("SELECT id FROM outreach_leads WHERE website = ? OR email = ? LIMIT 1");
+        $check->execute([$canonicalUrl, $email]);
+    } else {
+        $check = $pdo->prepare("SELECT id FROM outreach_leads WHERE website = ? LIMIT 1");
+        $check->execute([$canonicalUrl]);
+    }
+    if ($existing = $check->fetchColumn()) {
+        json_response([
+            'success'          => false,
+            'message'          => 'A lead with this creator or email already exists',
+            'existing_lead_id' => (int) $existing,
+        ], 409);
+    }
+
+    try {
+        $stmt = $pdo->prepare("INSERT INTO outreach_leads
+            (business_name, contact_name, email, website, source, contact_page_url, business_summary, category, country)
+            VALUES (?, ?, ?, ?, 'creator_auto', ?, ?, ?, 'US')");
+        $stmt->execute([
+            $name,
+            $name,
+            $email !== '' ? $email : null,
+            $canonicalUrl,
+            $canonicalUrl,
+            $summary,
+            'creator:' . $platform,
+        ]);
+        $leadId = (int) $pdo->lastInsertId();
+
+        $stmt = $pdo->prepare("INSERT INTO outreach_creator_candidates
+            (canonical_url, status, lead_id, platform, creator_name, harvested_email, last_query)
+            VALUES (?, 'imported', ?, ?, ?, ?, 'admin-ui')
+            ON DUPLICATE KEY UPDATE
+                status          = 'imported',
+                lead_id         = VALUES(lead_id),
+                platform        = VALUES(platform),
+                creator_name    = VALUES(creator_name),
+                harvested_email = VALUES(harvested_email)");
+        $stmt->execute([$canonicalUrl, $leadId, $platform, $name, $email]);
+
+        log_activity($pdo, $leadId, 'lead_created', 'Imported from Creators discovery UI');
+        json_response(['success' => true, 'lead_id' => $leadId]);
+    } catch (Exception $e) {
+        outreach_log("Creator import failed: " . $e->getMessage());
         json_response(['success' => false, 'message' => 'Database error: ' . $e->getMessage()], 500);
     }
 }

--- a/admin/outreach/index.php
+++ b/admin/outreach/index.php
@@ -65,7 +65,7 @@ include __DIR__ . '/../admin_header.php';
 // everything else (including legacy URLs without a tab param) maps to email.
 $redditTabs = ['reddit-threads', 'reddit-settings'];
 $activeChannel = $_GET['channel'] ?? (in_array($activeTab, $redditTabs, true) ? 'reddit' : 'email');
-if (!in_array($activeChannel, ['email', 'reddit', 'editorial'], true)) {
+if (!in_array($activeChannel, ['email', 'reddit', 'editorial', 'creator'], true)) {
     $activeChannel = 'email';
 }
 ?>
@@ -75,6 +75,7 @@ if (!in_array($activeChannel, ['email', 'reddit', 'editorial'], true)) {
     <button class="channel-tab <?php echo $activeChannel === 'email' ? 'active' : ''; ?>" data-channel="email">Email</button>
     <button class="channel-tab <?php echo $activeChannel === 'reddit' ? 'active' : ''; ?>" data-channel="reddit">Reddit</button>
     <button class="channel-tab <?php echo $activeChannel === 'editorial' ? 'active' : ''; ?>" data-channel="editorial">Editorial</button>
+    <button class="channel-tab <?php echo $activeChannel === 'creator' ? 'active' : ''; ?>" data-channel="creator">Partners</button>
 </div>
 
 <!-- Email channel -->
@@ -602,6 +603,156 @@ if ($activeChannel === 'reddit' && !in_array($activeTab, ['reddit-threads', 'red
         </div>
     </div>
 </div> <!-- /.channel-pane[data-channel-pane="editorial"] -->
+
+<div class="channel-pane <?php echo $activeChannel === 'creator' ? 'active' : ''; ?>" data-channel-pane="creator">
+
+    <div class="section-tabs">
+        <button class="section-tab active" data-tab="creator-discovery">Discovery</button>
+        <button class="section-tab" data-tab="creator-leads">Leads</button>
+    </div>
+
+    <div id="creator-discovery" class="tab-content active">
+        <div class="panel discovery-panel">
+            <div class="panel-header" onclick="togglePanel('creatorContent')">
+                <h2><?= svg_icon('search', 18) ?> Creators / Affiliate Partners</h2>
+                <span class="panel-toggle" id="creatorToggle">&#9660;</span>
+            </div>
+            <div class="panel-content" id="creatorContent">
+                <div class="discovery-form">
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="creatorLimit">How many creators to find</label>
+                            <input type="number" id="creatorLimit" value="8" min="1" max="30">
+                        </div>
+                        <div class="form-group form-group-btn">
+                            <button class="btn btn-blue" onclick="runCreatorDiscovery()" id="creatorRunBtn">Run</button>
+                        </div>
+                    </div>
+                    <p class="text-muted" style="margin:8px 0 0; font-size:13px; text-align:center;">
+                        Finds YouTubers, newsletter writers, and niche bloggers whose audience is small businesses and freelancers, then drafts an affiliate-partner pitch (50% recurring). Emails are harvested from linked sites where possible; YouTube emails are captcha-gated, so those come in without one for manual or assisted contact. SerpAPI usage today: <span id="creatorSerpUsage">&hellip;</span> &middot; Hunter.io: <span id="creatorHunterState">&hellip;</span>.
+                    </p>
+
+                    <div class="form-row" style="margin-top:16px; padding-top:16px; border-top:1px solid var(--border-color, #e2e8f0);">
+                        <div class="form-group" style="flex:1;">
+                            <label for="creatorUrl">Or add a specific creator URL (YouTube channel, newsletter, blog, LinkedIn)</label>
+                            <input type="text" id="creatorUrl" placeholder="https://youtube.com/@somechannel" style="width:100%;">
+                        </div>
+                        <div class="form-group form-group-btn">
+                            <button class="btn btn-blue" onclick="addCreatorUrl()" id="creatorAddBtn">Add</button>
+                        </div>
+                    </div>
+                    <p class="text-muted" style="margin:8px 0 0; font-size:12px; text-align:center;">
+                        Researches the creator and scrapes a contact email if one is public, then adds them to your Leads. LinkedIn profiles are added as a manual list (no email, no auto-draft).
+                    </p>
+                </div>
+
+                <div id="creatorResults" style="display:none; margin-top:16px;">
+                    <div class="discovery-actions">
+                        <span id="creatorResultsCount">0 results</span>
+                        <div>
+                            <button class="btn btn-small btn-blue" onclick="importAllCreatorFits()" id="creatorImportAllBtn">Import All Fits</button>
+                        </div>
+                    </div>
+                    <div class="discovery-table-wrapper">
+                        <table class="data-table discovery-table" data-paginate="25">
+                            <thead>
+                                <tr>
+                                    <th>Creator</th>
+                                    <th>Platform</th>
+                                    <th>Audience</th>
+                                    <th>Email</th>
+                                    <th>Profile</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody id="creatorResultsBody"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <p class="text-muted" style="margin-top:12px; font-size:13px;">
+            Imported creators become leads in the <strong>Leads</strong> tab above, where you review the AI-drafted affiliate pitch and send it. Keep Send mode on Review-before-send.
+        </p>
+    </div>
+
+    <div id="creator-leads" class="tab-content">
+        <!-- Filters -->
+        <div class="control-bar">
+            <div class="control-group">
+                <span class="control-label">Search</span>
+                <input type="text" class="control-input" id="crFilterSearch" placeholder="Creator, email..." oninput="debounceLoadCreatorLeads()">
+            </div>
+            <div class="control-group">
+                <span class="control-label">Status</span>
+                <select class="control-select" id="crFilterStatus" onchange="loadCreatorLeads()">
+                    <option value="">All</option>
+                    <option value="new">New</option>
+                    <option value="draft_generated">Draft Generated</option>
+                    <option value="contacted">Contacted</option>
+                    <option value="replied">Replied</option>
+                    <option value="interested">Interested</option>
+                    <option value="not_interested">Not Interested</option>
+                    <option value="onboarded">Onboarded</option>
+                    <option value="disqualified">Disqualified</option>
+                </select>
+            </div>
+            <div class="control-group">
+                <span class="control-label">Response</span>
+                <select class="control-select" id="crFilterResponse" onchange="loadCreatorLeads()">
+                    <option value="">All</option>
+                    <option value="no_response">No Response</option>
+                    <option value="positive">Positive</option>
+                    <option value="neutral">Neutral</option>
+                    <option value="negative">Negative</option>
+                </select>
+            </div>
+            <div class="control-group">
+                <span class="control-label">Sort</span>
+                <select class="control-select" id="crFilterSort" onchange="loadCreatorLeads()">
+                    <option value="date_added_desc">Newest First</option>
+                    <option value="date_added_asc">Oldest First</option>
+                    <option value="last_contact_desc">Last Contacted</option>
+                    <option value="business_name_asc">Name A-Z</option>
+                </select>
+            </div>
+        </div>
+
+        <!-- Bulk Actions -->
+        <div class="bulk-actions-bar" id="crBulkActionsBar" style="display:none;">
+            <span><strong id="crSelectedCount">0</strong> selected</span>
+            <button class="btn btn-small btn-blue" id="crBtnDraftSelected" onclick="bulkGenerateCreatorDrafts()">Draft Selected</button>
+            <button class="btn btn-small btn-blue" onclick="openCreatorBulkSend()">Send Email</button>
+            <button class="btn btn-small btn-blue" onclick="bulkDeleteCreatorLeads()">Delete Selected</button>
+        </div>
+
+        <!-- Bulk Draft Progress -->
+        <div class="bulk-draft-progress" id="crBulkDraftProgress" style="display:none;">
+            <span class="bulk-draft-spinner"></span>
+            <span id="crBulkDraftProgressText"></span>
+            <button class="btn btn-small btn-neutral" id="crBtnCancelDraft" onclick="cancelBulkDrafts()" style="margin-left:8px;">Cancel</button>
+        </div>
+
+        <div class="leads-table-wrapper">
+            <table class="data-table creator-leads-table">
+                <thead>
+                    <tr>
+                        <th class="checkbox-column"><div class="checkbox"><input type="checkbox" id="crLeadsSelectAll" onchange="toggleCreatorLeadCheckboxes(this)"><label for="crLeadsSelectAll"></label></div></th>
+                        <th>Creator</th>
+                        <th>Platform</th>
+                        <th>Email</th>
+                        <th>Status</th>
+                        <th>Sent</th>
+                        <th>Clicked</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="creatorLeadsTableBody"></tbody>
+            </table>
+        </div>
+    </div>
+</div> <!-- /.channel-pane[data-channel-pane="creator"] -->
 
 <!-- Lead Detail Modal -->
 <div id="leadDetailModal" class="modal" style="display:none;">

--- a/admin/outreach/outreach.js
+++ b/admin/outreach/outreach.js
@@ -548,9 +548,10 @@ async function executeBulkSend() {
     if (success > 0) {
         loadLeads();
         loadStats();
-        // Refresh the editorial leads table too if it was ever populated, so a
-        // bulk send launched from the Editorial tab reflects the new sent status.
+        // Refresh the editorial/creator leads tables too if they were ever
+        // populated, so a bulk send launched from those tabs reflects the new status.
         if (editorialLeadsPaginator) loadEditorialLeads();
+        if (creatorLeadsPaginator) loadCreatorLeads();
     }
 }
 
@@ -1982,6 +1983,343 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Creators / affiliate-partner outreach channel
+// Mirrors the editorial channel (discovery + leads with filters/bulk), scoped to
+// source=creator_auto, reusing the shared runBulkDrafts()/openBulkSendModal() and
+// the id-driven lead modal. Distinct classes/IDs (.cr-lead-check, cr*) so its
+// selection never collides with the other leads tables in the DOM.
+// ═══════════════════════════════════════════════════════════════════════════
+
+let creatorResults = [];
+let creatorLastSummary = null;
+let creatorLeadsPaginator = null;
+
+async function loadCreatorStatus() {
+    try {
+        const data = await api('creator_get_status');
+        if (data.success) {
+            const usage = document.getElementById('creatorSerpUsage');
+            if (usage) usage.textContent = `${data.serpapi_calls_today}/${data.serpapi_limit} queries`;
+            const hunter = document.getElementById('creatorHunterState');
+            if (hunter) hunter.textContent = data.has_hunter ? 'connected' : 'not set (scrapes linked sites instead)';
+        }
+    } catch (e) { /* non-fatal */ }
+}
+
+async function runCreatorDiscovery() {
+    const limit = Math.min(30, Math.max(1, parseInt(document.getElementById('creatorLimit').value, 10) || 8));
+    const btn = document.getElementById('creatorRunBtn');
+    btn.disabled = true;
+    btn.textContent = 'Searching…';
+    try {
+        const data = await api('creator_run_discovery', { method: 'POST', body: { limit } });
+        if (!data.success) {
+            notify(data.message || 'Creator discovery failed');
+            return;
+        }
+        creatorResults = data.results || [];
+        creatorLastSummary = {
+            rejected_count: data.rejected_count || 0,
+            reject_reasons: data.reject_reasons || {},
+            already_imported_count: data.already_imported_count || 0,
+            already_rejected_count: data.already_rejected_count || 0,
+            total_evaluated: data.total_evaluated || 0,
+            requested_limit: data.requested_limit || limit,
+            quota_exhausted: !!data.quota_exhausted,
+            stop_reason: data.stop_reason || '',
+        };
+        const usage = document.getElementById('creatorSerpUsage');
+        if (usage) usage.textContent = `${data.serpapi_calls_today}/${data.serpapi_limit} queries`;
+        document.getElementById('creatorResults').style.display = 'block';
+        renderCreatorResults();
+        if (creatorLastSummary.quota_exhausted) {
+            notify(`SerpAPI daily quota hit before finding ${creatorLastSummary.requested_limit}. Got ${creatorResults.length} fit${creatorResults.length === 1 ? '' : 's'}. Resets at midnight or raise SERPAPI_DAILY_QUERY_LIMIT in .env.`);
+        }
+    } catch (e) {
+        notify(e.message);
+    } finally {
+        btn.disabled = false;
+        btn.textContent = 'Run';
+    }
+}
+
+function renderCreatorResults() {
+    const body = document.getElementById('creatorResultsBody');
+    const countEl = document.getElementById('creatorResultsCount');
+    const importAllBtn = document.getElementById('creatorImportAllBtn');
+    const safe = (s) => escapeHtml(String(s ?? ''));
+
+    let summary = `${creatorResults.length} fit`;
+    if (creatorLastSummary) {
+        if (creatorLastSummary.already_imported_count > 0) summary += ` · ${creatorLastSummary.already_imported_count} already imported (hidden)`;
+        if (creatorLastSummary.already_rejected_count > 0) summary += ` · ${creatorLastSummary.already_rejected_count} previously skipped (hidden)`;
+        if (creatorLastSummary.rejected_count > 0) {
+            const reasons = creatorLastSummary.reject_reasons || {};
+            const reasonStr = Object.entries(reasons).sort((a, b) => b[1] - a[1]).slice(0, 3).map(([k, n]) => `${n}× ${k}`).join(', ');
+            summary += ` · ${creatorLastSummary.rejected_count} skipped`;
+            if (reasonStr) summary += ` (${reasonStr})`;
+        }
+    }
+    countEl.textContent = summary;
+
+    if (importAllBtn) {
+        importAllBtn.disabled = creatorResults.length === 0;
+        importAllBtn.textContent = creatorResults.length > 0 ? `Import ${creatorResults.length} Fit${creatorResults.length !== 1 ? 's' : ''}` : 'Import All Fits';
+    }
+
+    if (creatorResults.length === 0) {
+        const n = (creatorLastSummary && creatorLastSummary.total_evaluated) || 0;
+        body.innerHTML = `<tr><td colspan="6" style="text-align:center; padding:24px; color:#888;">No new creators to recruit (evaluated ${n}). They were not a fit for the audience, or already imported.</td></tr>`;
+        return;
+    }
+
+    body.innerHTML = creatorResults.map((r, idx) => {
+        const name = `<div><strong>${safe(r.creator_name) || safe(r.canonical_url)}</strong></div>`;
+        const emailSrc = r.email_source ? ` <span style="color:#888; font-size:11px;">(${safe(r.email_source)})</span>` : '';
+        const emailCell = r.email ? (safe(r.email) + emailSrc) : '<span style="color:#c00; font-size:12px;">manual</span>';
+        return '<tr>' +
+            `<td>${name}</td>` +
+            `<td><span class="badge">${safe(r.platform) || '—'}</span></td>` +
+            `<td style="max-width:200px; font-size:12px;">${safe(r.audience) || '—'}</td>` +
+            `<td>${emailCell}</td>` +
+            `<td><a href="${safe(r.canonical_url)}" target="_blank" rel="noopener" class="link">open</a></td>` +
+            `<td><button class="btn btn-small btn-blue" onclick="importCreatorRow(${idx}, this)">Import</button></td>` +
+        '</tr>';
+    }).join('');
+}
+
+async function importCreatorRow(idx, btn) {
+    const row = creatorResults[idx];
+    if (!row) return;
+    btn.disabled = true;
+    btn.textContent = 'Importing…';
+    try {
+        const data = await api('creator_import', { method: 'POST', body: {
+            canonical_url: row.canonical_url,
+            platform: row.platform,
+            creator_name: row.creator_name,
+            email: row.email,
+            business_summary: row.business_summary
+        } });
+        if (data.success) {
+            creatorResults = creatorResults.filter(r => r.canonical_url !== row.canonical_url);
+            if (creatorLastSummary) creatorLastSummary.already_imported_count = (creatorLastSummary.already_imported_count || 0) + 1;
+            renderCreatorResults();
+            loadStats();
+            loadCreatorLeads();
+        } else {
+            notify(data.message || 'Import failed');
+            btn.disabled = false;
+            btn.textContent = 'Import';
+        }
+    } catch (e) {
+        notify(e.message);
+        btn.disabled = false;
+        btn.textContent = 'Import';
+    }
+}
+
+async function importAllCreatorFits() {
+    if (creatorResults.length === 0) return;
+    if (!confirm(`Import ${creatorResults.length} creator${creatorResults.length === 1 ? '' : 's'} as new partner leads?`)) return;
+    const toImport = creatorResults.map(r => ({
+        canonical_url: r.canonical_url,
+        platform: r.platform,
+        creator_name: r.creator_name,
+        email: r.email,
+        business_summary: r.business_summary
+    }));
+    const btn = document.getElementById('creatorImportAllBtn');
+    btn.disabled = true;
+    btn.textContent = 'Importing…';
+    const succeeded = new Set();
+    let failed = 0;
+    for (const item of toImport) {
+        try {
+            const data = await api('creator_import', { method: 'POST', body: item });
+            if (data.success) succeeded.add(item.canonical_url);
+            else failed++;
+        } catch (e) {
+            failed++;
+        }
+    }
+    creatorResults = creatorResults.filter(r => !succeeded.has(r.canonical_url));
+    if (creatorLastSummary) creatorLastSummary.already_imported_count = (creatorLastSummary.already_imported_count || 0) + succeeded.size;
+    renderCreatorResults();
+    loadStats();
+    loadCreatorLeads();
+    notify(`Imported ${succeeded.size} lead${succeeded.size === 1 ? '' : 's'}` + (failed > 0 ? `, ${failed} failed` : ''));
+}
+
+// Add one specific creator URL directly (YouTube channel, newsletter, blog, or a
+// LinkedIn profile which imports as a manual, email-less lead).
+async function addCreatorUrl() {
+    const input = document.getElementById('creatorUrl');
+    const url = (input.value || '').trim();
+    if (!url) { notify('Enter a creator URL'); return; }
+    const btn = document.getElementById('creatorAddBtn');
+    btn.disabled = true;
+    btn.textContent = 'Adding…';
+    try {
+        const data = await api('creator_add_url', { method: 'POST', body: { url } });
+        if (data.success) {
+            input.value = '';
+            const emailMsg = data.has_email ? `email ${data.email}` : 'no email found — add it on the lead or use assisted email';
+            notify(`Added ${data.name || 'creator'} (${data.platform || ''}, ${emailMsg})`, 'success');
+            loadCreatorLeads();
+            loadStats();
+        } else {
+            notify(data.message || 'Could not add that URL');
+        }
+    } catch (e) {
+        notify(e.message);
+    } finally {
+        btn.disabled = false;
+        btn.textContent = 'Add';
+    }
+}
+
+// ─── Creator Leads: bulk select (distinct .cr-lead-check class / cr* IDs) ───
+function toggleCreatorLeadCheckboxes(master) {
+    document.querySelectorAll('.cr-lead-check').forEach(cb => cb.checked = master.checked);
+    updateCreatorBulkBar();
+}
+
+function updateCreatorBulkBar() {
+    const checked = document.querySelectorAll('.cr-lead-check:checked');
+    const bar = document.getElementById('crBulkActionsBar');
+    const count = document.getElementById('crSelectedCount');
+    const selectAll = document.getElementById('crLeadsSelectAll');
+    const allBoxes = document.querySelectorAll('.cr-lead-check');
+
+    if (bar) bar.style.display = checked.length ? 'flex' : 'none';
+    if (count) count.textContent = checked.length;
+
+    if (selectAll && allBoxes.length) {
+        if (checked.length === 0) { selectAll.checked = false; selectAll.indeterminate = false; }
+        else if (checked.length === allBoxes.length) { selectAll.checked = true; selectAll.indeterminate = false; }
+        else { selectAll.checked = false; selectAll.indeterminate = true; }
+    }
+
+    const draftBtn = document.getElementById('crBtnDraftSelected');
+    if (draftBtn) {
+        const allDrafted = checked.length > 0 && Array.from(checked).every(cb => cb.dataset.hasDraft === '1');
+        draftBtn.textContent = allDrafted ? 'Redraft Selected' : 'Draft Selected';
+    }
+}
+
+function getSelectedCreatorLeadIds() {
+    return Array.from(document.querySelectorAll('.cr-lead-check:checked')).map(cb => parseInt(cb.value));
+}
+
+function bulkGenerateCreatorDrafts() {
+    return runBulkDrafts({
+        ids: getSelectedCreatorLeadIds(),
+        checkClass: '.cr-lead-check', checkIdPrefix: 'cr-lead-check-',
+        progressId: 'crBulkDraftProgress', progressTextId: 'crBulkDraftProgressText',
+        cancelBtnId: 'crBtnCancelDraft', draftBtnId: 'crBtnDraftSelected',
+        onDone: updateCreatorBulkBar,
+    });
+}
+
+function openCreatorBulkSend() {
+    openBulkSendModal(getSelectedCreatorLeadIds());
+}
+
+async function bulkDeleteCreatorLeads() {
+    const ids = getSelectedCreatorLeadIds();
+    if (!ids.length) return;
+    if (!confirm(`Delete ${ids.length} lead(s)? This cannot be undone.`)) return;
+
+    let success = 0, fail = 0, lastError = '';
+    for (const id of ids) {
+        try {
+            const result = await api('delete_lead', { method: 'POST', body: { id } });
+            if (result.success) success++; else { fail++; lastError = result.message || 'Unknown error'; }
+        } catch (err) { fail++; lastError = err.message; }
+    }
+    if (fail > 0) notify(`Deleted: ${success}, Failed: ${fail}. Last error: ${lastError}`, 'error');
+    else notify(`Successfully deleted ${success} lead(s)`, 'success');
+    loadCreatorLeads();
+    loadStats();
+}
+
+function debounceLoadCreatorLeads() {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(loadCreatorLeads, 300);
+}
+
+async function loadCreatorLeads() {
+    const tbody = document.getElementById('creatorLeadsTableBody');
+    if (!tbody) return;
+
+    const params = { source: 'creator_auto' };
+    const searchEl = document.getElementById('crFilterSearch');
+    const statusEl = document.getElementById('crFilterStatus');
+    const responseEl = document.getElementById('crFilterResponse');
+    const sortEl = document.getElementById('crFilterSort');
+    if (searchEl && searchEl.value.trim()) params.search = searchEl.value.trim();
+    if (statusEl && statusEl.value) params.status = statusEl.value;
+    if (responseEl && responseEl.value) params.response_status = responseEl.value;
+    params.sort = (sortEl && sortEl.value) ? sortEl.value : 'date_added_desc';
+
+    try {
+        const data = await api('get_leads', { params });
+        if (!data.success || !data.leads.length) {
+            tbody.innerHTML = '<tr><td colspan="8" class="empty-state">No partner leads found.</td></tr>';
+            if (creatorLeadsPaginator) creatorLeadsPaginator.reset();
+            const selectAll = document.getElementById('crLeadsSelectAll');
+            if (selectAll) selectAll.checked = false;
+            updateCreatorBulkBar();
+            return;
+        }
+        tbody.innerHTML = data.leads.map(lead => {
+            const platform = (lead.category || '').replace(/^creator:/, '') || '—';
+            return `
+            <tr class="lead-row">
+                <td class="checkbox-column" onclick="event.stopPropagation()">
+                    <div class="checkbox"><input type="checkbox" class="cr-lead-check" value="${lead.id}" id="cr-lead-check-${lead.id}" data-has-draft="${lead.draft_subject ? '1' : ''}" onchange="updateCreatorBulkBar()"><label for="cr-lead-check-${lead.id}"></label></div>
+                </td>
+                <td>
+                    <strong>${esc(lead.business_name)}</strong>
+                    ${lead.website ? '<br><a class="website-link" href="' + esc(lead.website) + '" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">' + esc(lead.website.replace(/^https?:\/\//, '').replace(/\?.*$/, '')) + '</a>' : ''}
+                </td>
+                <td><span class="badge">${esc(platform)}</span></td>
+                <td>${lead.email ? esc(lead.email) : '<span class="text-muted">—</span>'}</td>
+                <td><span class="badge badge-status-${lead.status || 'new'}">${formatStatus(lead.status || 'new')}</span></td>
+                <td>${lead.sent_at ? formatDateTime(lead.sent_at) : '<span class="text-muted">—</span>'}</td>
+                <td>${lead.clicked_at ? formatDateTime(lead.clicked_at) : '<span class="text-muted">—</span>'}</td>
+                <td onclick="event.stopPropagation()">
+                    <div class="actions-cell">
+                        <button class="btn btn-small btn-blue" onclick="openLeadDetail(${lead.id})" title="View">View</button>
+                        ${lead.email && !lead.draft_subject && !['contacted','replied','interested','not_interested','onboarded'].includes(lead.status) ? `<button class="btn btn-small btn-blue" onclick="quickGenerateDraft(${lead.id}, this)" title="Generate Draft">Draft</button>` : ''}
+                    </div>
+                </td>
+            </tr>`;
+        }).join('');
+
+        const selectAll = document.getElementById('crLeadsSelectAll');
+        if (selectAll) selectAll.checked = false;
+        updateCreatorBulkBar();
+
+        const table = document.querySelector('.creator-leads-table');
+        if (table) {
+            if (!creatorLeadsPaginator) creatorLeadsPaginator = new TablePaginator(table, { perPage: 25 });
+            else creatorLeadsPaginator.reset();
+        }
+    } catch (e) {
+        notify(e.message, 'error');
+    }
+}
+
+document.querySelectorAll('.section-tab[data-tab="creator-leads"]').forEach(btn =>
+    btn.addEventListener('click', () => setTimeout(loadCreatorLeads, 0)));
+document.addEventListener('DOMContentLoaded', function () {
+    loadCreatorStatus();
+    if (document.querySelector('#creator-leads.tab-content.active')) loadCreatorLeads();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Reddit outreach
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -2020,7 +2358,7 @@ function switchChannel(channel) {
     try {
         const url = new URL(window.location.href);
         url.searchParams.set('channel', channel);
-        if (channel === 'email' && /^(reddit|editorial)-/.test(url.searchParams.get('tab') || '')) {
+        if (channel === 'email' && /^(reddit|editorial|creator)-/.test(url.searchParams.get('tab') || '')) {
             url.searchParams.set('tab', 'leads');
         }
         if (channel === 'reddit' && !['reddit-threads', 'reddit-settings'].includes(url.searchParams.get('tab') || '')) {
@@ -2028,6 +2366,9 @@ function switchChannel(channel) {
         }
         if (channel === 'editorial') {
             url.searchParams.set('tab', 'editorial-discovery');
+        }
+        if (channel === 'creator') {
+            url.searchParams.set('tab', 'creator-discovery');
         }
         history.replaceState({}, '', url.toString());
     } catch (e) { /* ignore */ }
@@ -2049,6 +2390,9 @@ function switchChannel(channel) {
     }
     if (channel === 'editorial') {
         loadEditorialStatus();
+    }
+    if (channel === 'creator') {
+        loadCreatorStatus();
     }
 }
 

--- a/cron/lib/creator_discovery.php
+++ b/cron/lib/creator_discovery.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * Creator / affiliate-partner discovery for the outreach pipeline.
+ *
+ * Finds content creators and publications whose audience is small-business
+ * owners, freelancers, bookkeepers, or accountants, YouTubers, newsletter
+ * writers, and niche bloggers, so we can pitch them the Argo Books AFFILIATE
+ * program (50% recurring for a referred customer's first 12 months). This is a
+ * money proposition, unlike the editorial channel's "add me to your roundup"
+ * pitch, so the audiences overlap but the ask is different.
+ *
+ * Reuses the shared discovery helpers (paginated SerpAPI cache, page fetch,
+ * email scrape, Gemini) so it inherits the same pagination + target-count loop
+ * behavior the editorial and shopify channels use. Pure helpers only: no DB
+ * writes here beyond the SerpAPI cache the wrapper owns; the caller orchestrates
+ * candidate/lead inserts.
+ *
+ * Honest limits, baked into the design:
+ *   - YouTube deliberately hides the About-page business email behind a captcha,
+ *     so email is harvested only when a creator links a scrapeable site/Linktree.
+ *     Channels without a findable email are still imported (email left blank) so
+ *     they can be worked manually or via the assisted-captcha helper.
+ *   - LinkedIn blocks scraping; profile URLs are surfaced as a manual list only
+ *     (no auto email, no auto draft). See creator_platform_from_url().
+ */
+
+require_once __DIR__ . '/shopify_discovery.php'; // serpapi_query_cached(), _shopify_url_is_safe_external(), + outreach_helpers
+require_once __DIR__ . '/editorial_discovery.php'; // hunter_find_email(), editorial_domain_from_url(), editorial_detect_affiliate()
+
+/**
+ * Topic queries that surface creators/publications in our niche. Kept broad on
+ * intent (audience = freelancers / small business / bookkeeping) and mixed
+ * across platforms; creator_platform_from_url() then classifies each result.
+ */
+const CREATOR_QUERY_POOL = [
+    'best accounting software youtube review',
+    'bookkeeping tips for freelancers youtube',
+    'small business finance youtube channel',
+    'quickbooks alternative review youtube',
+    'freelance finances newsletter',
+    'small business bookkeeping newsletter',
+    'accounting software review blog',
+    'bookkeeping for small business blog',
+    'freelancer tax and bookkeeping tips',
+    'solopreneur finance newsletter',
+    'best free accounting software for freelancers',
+    'invoicing tips for small business owners',
+];
+
+/** Newsletter-platform hosts we treat as "newsletter" for the pitch angle. */
+const CREATOR_NEWSLETTER_HOSTS = [
+    'substack.com', 'beehiiv.com', 'ghost.io', 'buttondown.com', 'buttondown.email',
+    'convertkit.com', 'kit.com', 'mailchimp.com', 'revue', 'letterdrop.com',
+];
+
+/**
+ * Classify a result URL into a creator platform. Drives the pitch angle and,
+ * critically, whether we even try to auto-harvest an email.
+ *
+ * @return string one of 'youtube' | 'newsletter' | 'linkedin' | 'blog'
+ */
+function creator_platform_from_url(string $url): string
+{
+    $host = strtolower((string) (parse_url($url, PHP_URL_HOST) ?: ''));
+    if ($host === '') {
+        return 'blog';
+    }
+    if (str_contains($host, 'youtube.com') || str_contains($host, 'youtu.be')) {
+        return 'youtube';
+    }
+    if (str_contains($host, 'linkedin.com')) {
+        return 'linkedin';
+    }
+    foreach (CREATOR_NEWSLETTER_HOSTS as $n) {
+        if (str_contains($host, $n)) {
+            return 'newsletter';
+        }
+    }
+    return 'blog';
+}
+
+/**
+ * Canonicalize a creator URL to a stable identity for dedup.
+ *
+ * For YouTube, collapse to the channel (/@handle, /channel/ID, /c/name, /user/name)
+ * so many video links to one creator dedup to a single candidate. For everything
+ * else, lowercase scheme+host, keep the path, drop query/fragment (same rule as
+ * editorial). Returns the trimmed input on parse failure.
+ */
+function creator_canonical_url(string $url): string
+{
+    $url = trim($url);
+    if ($url === '') {
+        return '';
+    }
+    $parts = parse_url($url);
+    if ($parts === false || empty($parts['host'])) {
+        return $url;
+    }
+    $scheme = isset($parts['scheme']) ? strtolower($parts['scheme']) : 'https';
+    $host   = strtolower($parts['host']);
+    $path   = $parts['path'] ?? '';
+
+    if (str_contains($host, 'youtube.com')) {
+        // Keep only the channel-identifying first path segment (@handle) or the
+        // /channel|/c|/user + name pair; strip /watch, /shorts, etc.
+        if (preg_match('#^/(@[^/]+)#', $path, $m)) {
+            $path = '/' . $m[1];
+        } elseif (preg_match('#^/(channel|c|user)/([^/]+)#', $path, $m)) {
+            $path = '/' . $m[1] . '/' . $m[2];
+        } else {
+            $path = ''; // a bare youtube.com/watch?v=... has no channel identity here
+        }
+    } else {
+        $path = rtrim($path, '/');
+    }
+
+    return $scheme . '://' . $host . $path;
+}
+
+/**
+ * Run one creator SERP query (paginated) and return canonicalized candidate URLs
+ * with their SERP title and detected platform. Reuses the shared SerpAPI cache
+ * wrapper, so it inherits the same page offset + 14-day cache behavior.
+ *
+ * @return array{results: array<int, array{url:string,title:string,platform:string}>, from_cache: bool}
+ */
+function creator_search(string $query, string $apiKey, int $limit, PDO $pdo, int $start = 0): array
+{
+    $resp = serpapi_query_cached($query, $apiKey, $limit, $pdo, $start);
+    $out  = [];
+    $seen = [];
+    foreach ($resp['results'] as $r) {
+        $link = (string) ($r['link'] ?? '');
+        if ($link === '') {
+            continue;
+        }
+        $canon = creator_canonical_url($link);
+        if ($canon === '' || isset($seen[$canon])) {
+            continue;
+        }
+        $domain = editorial_domain_from_url($canon);
+        // Skip our own site and generic aggregators that aren't a single creator.
+        if ($domain === '' || str_contains($domain, 'argorobots.com')) {
+            continue;
+        }
+        $seen[$canon] = true;
+        $out[] = [
+            'url'      => $canon,
+            'title'    => (string) ($r['title'] ?? ''),
+            'platform' => creator_platform_from_url($canon),
+        ];
+    }
+    return ['results' => $out, 'from_cache' => $resp['from_cache']];
+}
+
+/**
+ * Evaluate a candidate creator/publication: is its audience a fit for an Argo
+ * Books affiliate pitch, who is it, and can we find a contact email? Returns a
+ * result shaped like the other evaluators (fit/reason/detail/final_url/metadata).
+ *
+ * $force skips the relevance gate for a hand-added URL (a deliberate operator
+ * choice), and always allows import even with no email found.
+ *
+ * @return array{fit: bool, reason: string, detail: string, final_url: string, metadata: array<string,mixed>}
+ */
+function evaluate_creator_candidate(string $url, PDO $pdo, string $serpTitle = '', bool $force = false): array
+{
+    $fail = static function (string $reason, string $detail, string $finalUrl, array $meta = []): array {
+        return ['fit' => false, 'reason' => $reason, 'detail' => $detail, 'final_url' => $finalUrl, 'metadata' => $meta];
+    };
+
+    if (!_shopify_url_is_safe_external($url)) {
+        return $fail('unsafe_url', 'URL resolves to a private/reserved address', $url);
+    }
+
+    $platform = creator_platform_from_url($url);
+    $domain   = editorial_domain_from_url($url);
+
+    // LinkedIn is a manual list only: we can surface the profile URL but cannot
+    // scrape contents or an email (blocked + against ToS). Import with no email
+    // and no draft so the operator can reach out by hand.
+    if ($platform === 'linkedin') {
+        if (!$force) {
+            return $fail('linkedin_manual', 'LinkedIn profiles are a manual list (no scraping)', $url, [
+                'platform' => 'linkedin', 'domain' => $domain,
+            ]);
+        }
+        return [
+            'fit' => true, 'reason' => 'fit', 'detail' => 'LinkedIn profile (manual outreach)', 'final_url' => $url,
+            'metadata' => [
+                'platform'         => 'linkedin',
+                'creator_name'     => $serpTitle !== '' ? mb_substr($serpTitle, 0, 150) : $domain,
+                'domain'           => $domain,
+                'email'            => '',
+                'email_source'     => null,
+                'audience'         => '',
+                'business_summary' => mb_substr('LinkedIn profile: ' . ($serpTitle !== '' ? $serpTitle : $url) . '. Manual outreach only; no email harvested.', 0, 1000),
+            ],
+        ];
+    }
+
+    $fetched = fetch_website_text($url);
+    if ($fetched === null) {
+        // YouTube and some platforms are JS-heavy / block scrapers. Fall back to
+        // the SERP title so the candidate is still usable (email may be blank).
+        if ($serpTitle === '') {
+            return $fail('fetch_failed', 'Could not fetch the page and no SERP title to fall back on', $url, ['platform' => $platform]);
+        }
+        $fetched = ['text' => $serpTitle, 'html' => ''];
+    }
+
+    // One Gemini call: is the audience a fit, who is the creator, what do they cover?
+    $systemPrompt = <<<'PROMPT'
+You analyze a web page (a YouTube channel/video, a newsletter, or a blog) to decide
+whether its AUDIENCE is a good fit to promote Argo Books, a free bookkeeping and
+invoicing app for small businesses and freelancers, as an affiliate partner. Return
+ONLY a JSON object with exactly these keys:
+{"is_relevant": boolean, "creator_name": string|null, "audience": string|null, "topics": string[], "external_site": string|null}
+
+- is_relevant: true only if the creator/publication regularly reaches small-business
+  owners, freelancers, solopreneurs, bookkeepers, accountants, or similar people who
+  would use accounting/invoicing software. A general/unrelated channel is NOT relevant.
+- creator_name: the person's or publication's name/handle, or null.
+- audience: one short phrase describing who they reach (e.g. "freelance designers", "small e-commerce owners").
+- topics: up to 6 short topic tags the creator covers.
+- external_site: if the page shows a personal website, Linktree, or contact link OFF this
+  domain, return that URL (used to find a contact email). Otherwise null.
+No preamble, JSON only.
+PROMPT;
+
+    $res = call_gemini($systemPrompt, "URL: {$url}\nPlatform: {$platform}\nSERP title: {$serpTitle}\n\nPage text:\n" . $fetched['text']);
+    if (!empty($res['error']) || empty($res['content'])) {
+        return $fail('ai_error', 'AI evaluation failed: ' . ($res['error'] ?? 'empty'), $url, ['platform' => $platform]);
+    }
+    $content = preg_replace('/^```json\s*/i', '', trim((string) $res['content']));
+    $content = preg_replace('/\s*```$/', '', $content);
+    $parsed  = json_decode($content, true);
+    if (!is_array($parsed)) {
+        return $fail('ai_parse_failed', 'AI returned malformed JSON', $url, ['platform' => $platform]);
+    }
+
+    $isRelevant   = !empty($parsed['is_relevant']);
+    $creatorName  = trim((string) ($parsed['creator_name'] ?? '')) ?: ($serpTitle !== '' ? $serpTitle : ucfirst($domain));
+    $audience     = trim((string) ($parsed['audience'] ?? ''));
+    $topics       = is_array($parsed['topics'] ?? null) ? array_slice(array_map('strval', $parsed['topics']), 0, 6) : [];
+    $externalSite = trim((string) ($parsed['external_site'] ?? ''));
+
+    $baseMeta = [
+        'platform'     => $platform,
+        'creator_name' => mb_substr($creatorName, 0, 150),
+        'audience'     => mb_substr($audience, 0, 200),
+        'topics'       => $topics,
+        'domain'       => $domain,
+    ];
+
+    if (!$isRelevant && !$force) {
+        return $fail('not_relevant', 'Audience is not a fit for Argo Books', $url, $baseMeta);
+    }
+
+    // Find a contact email. Blogs/newsletters: scrape the site directly. YouTube:
+    // the email is captcha-gated, so the only automatable path is a site/Linktree
+    // the creator links (external_site) or their own domain if it isn't youtube.
+    $email       = null;
+    $emailSource = null;
+
+    $scrapeTargets = [];
+    if ($externalSite !== '' && filter_var($externalSite, FILTER_VALIDATE_EMAIL) === false) {
+        $scrapeTargets[] = $externalSite;
+    }
+    if ($platform !== 'youtube' && $domain !== '') {
+        $scrapeTargets[] = 'https://' . $domain . '/';
+    }
+    foreach ($scrapeTargets as $target) {
+        if (!_shopify_url_is_safe_external($target)) {
+            continue;
+        }
+        $scraped = scrape_email_from_website($target);
+        if ($scraped && filter_var($scraped, FILTER_VALIDATE_EMAIL)) {
+            $email = $scraped;
+            $emailSource = 'scraped';
+            break;
+        }
+    }
+    // Hunter fallback by creator name on a real (non-youtube) domain.
+    if ($email === null && $platform !== 'youtube' && $creatorName !== '' && $domain !== '') {
+        $hunterKey = $_ENV['HUNTER_API_KEY'] ?? '';
+        if ($hunterKey !== '') {
+            $hit = hunter_find_email($domain, $creatorName, $hunterKey);
+            if ($hit !== null) {
+                $email = $hit['email'];
+                $emailSource = 'hunter(score ' . $hit['score'] . ')';
+            }
+        }
+    }
+
+    $topicList = $topics ? implode(', ', $topics) : 'general';
+    $needsManualEmail = ($email === null);
+    $summary = ucfirst($platform) . " creator: \"{$creatorName}\""
+        . ($audience !== '' ? " reaching {$audience}" : '')
+        . ". Covers: {$topicList}."
+        . ($needsManualEmail
+            ? ' No email auto-found' . ($platform === 'youtube' ? ' (YouTube hides it behind a captcha, contact via their channel or the assisted-email helper).' : '.')
+            : '')
+        . ' Goal: recruit as an Argo Books affiliate partner.';
+
+    $meta = $baseMeta + [
+        'email'            => $email ?? '',
+        'email_source'     => $emailSource,
+        'external_site'    => $externalSite,
+        'needs_manual_email' => $needsManualEmail,
+        'business_summary' => mb_substr($summary, 0, 1000),
+    ];
+
+    return ['fit' => true, 'reason' => 'fit', 'detail' => 'Relevant creator', 'final_url' => $url, 'metadata' => $meta];
+}

--- a/cron/lib/editorial_discovery.php
+++ b/cron/lib/editorial_discovery.php
@@ -186,9 +186,9 @@ function hunter_find_email(string $domain, string $fullName, string $apiKey): ?a
  *
  * @return array{results: array<int, array{url:string,title:string,snippet:string}>, from_cache: bool}
  */
-function editorial_search(string $query, string $apiKey, int $limit, PDO $pdo): array
+function editorial_search(string $query, string $apiKey, int $limit, PDO $pdo, int $start = 0): array
 {
-    $resp = serpapi_query_cached($query, $apiKey, $limit, $pdo);
+    $resp = serpapi_query_cached($query, $apiKey, $limit, $pdo, $start);
     $out  = [];
     $seen = [];
     foreach ($resp['results'] as $r) {

--- a/cron/lib/outreach_helpers.php
+++ b/cron/lib/outreach_helpers.php
@@ -2178,7 +2178,11 @@ function generate_draft_for_lead($pdo, $lead)
     // AI size gate and the newness gate below don't apply. They also arrive with
     // their article context pre-summarized, so the SMB summary call is skipped.
     $isEditorial = ($sourceVal === 'editorial_auto');
-    $isAutoLead = str_ends_with($sourceVal, '_auto') && !$isEditorial;
+    // Creator/affiliate-partner leads are content creators and publications, not
+    // small businesses, so they skip the SMB size/newness gates just like
+    // editorial. Their pitch is an affiliate-recruitment email, not feedback.
+    $isCreator = ($sourceVal === 'creator_auto');
+    $isAutoLead = str_ends_with($sourceVal, '_auto') && !$isEditorial && !$isCreator;
     if ($isAutoLead) {
         $gate = classify_lead_size_with_ai($lead);
         if (isset($gate['error'])) {
@@ -2324,7 +2328,7 @@ function generate_draft_for_lead($pdo, $lead)
     $summary = $lead['business_summary'] ?? null;
     if ($personalizationOff) {
         $summary = null;
-    } elseif (empty($summary) && !empty($lead['website']) && !$isEditorial) {
+    } elseif (empty($summary) && !empty($lead['website']) && !$isEditorial && !$isCreator) {
         // Reuse the page text fetched by the newness gate above (if any) so we
         // don't fetch the same homepage twice.
         $summary = summarize_business($lead['website'], $prefetchedSiteText);
@@ -2369,7 +2373,38 @@ function generate_draft_for_lead($pdo, $lead)
         . $painPointsList
         . "You MAY gently allude to ONE of these as something Argo Books can help with, phrased as a general industry pattern (e.g. \"businesses like yours often deal with X\"), NEVER as an assertion about this specific business. Pick at most one. If none fit naturally, skip them entirely.";
 
-    if ($isEditorial) {
+    if ($isCreator) {
+        $systemPrompt = "You are helping write a short, genuine outreach email from Evan, the developer behind Argo Books, to a content creator or publication (a YouTuber, newsletter writer, or blogger) whose audience is small-business owners and freelancers. The goal is to recruit them as an AFFILIATE PARTNER who promotes Argo Books to their audience.
+
+About Argo Books:
+- A free, simple bookkeeping and invoicing app for small businesses, built so you need no accounting knowledge
+- Runs on Windows, macOS, and Linux, and works offline as a desktop app so your data stays on your computer
+- Genuinely free tier with no user cap; a paid Premium tier exists but the core is free
+- Made by Evan, a solo independent developer
+
+The affiliate offer:
+- 50% recurring commission on a referred customer's first 12 months of Premium
+- Free to join, real-time dashboard, PayPal payouts
+- Sign-up page: https://argorobots.com/affiliates
+
+Rules:
+- Keep it short (2-3 short paragraphs, under 130 words). Sound like one human emailing another, not a mass affiliate blast
+- Address the creator by name/handle if given in the context; otherwise a warm \"Hi there\"
+- First sentence: reference specifically what they do / who their audience is (from the context), so it is clearly not a mass mailing. Do NOT open with generic flattery like \"I love your content\"
+- Say briefly why Argo Books fits THEIR audience (free, no accounting knowledge needed, works offline), then make the affiliate offer plainly: 50% recurring for a referred customer's first 12 months
+- Include the sign-up link https://argorobots.com/affiliates
+- Be honest and low-pressure. It is a genuine partnership offer, not hype. Do NOT promise they will make a specific amount of money
+- NEVER use em dashes; use commas, periods, or regular hyphens. NEVER use placeholders like [Your Name]
+- The subject line should read like a real person proposing a partnership. Under 8 words. Good: \"partnership idea for your audience\", \"affiliate offer for [creator]\". Avoid salesy hooks$abSubjectOverride
+- End with a friendly line inviting a reply, then the sign-off
+- After the reply line, add ONE short, respectful opt-out line on its own paragraph: \"Not interested? {UNSUBSCRIBE_URL} and I won't follow up.\" Include the literal token {UNSUBSCRIBE_URL} verbatim; it is replaced with a real tracked link before sending
+- Sign off with three separate lines: \"Thanks,\" then \"Evan\" then \"Argo Books\" (each on its own line, separated by \\n)$abBodyOverride
+
+Return your response as JSON with two fields:
+{\"subject\": \"the email subject line\", \"body\": \"the email body text (plain text, use \\n for line breaks)\"}
+
+Return ONLY the JSON object, nothing else.";
+    } elseif ($isEditorial) {
         $systemPrompt = "You are helping write a short, genuine outreach email from Evan, the developer behind Argo Books, to the author or editor of a published \"best software\" roundup article. The goal is to get Argo Books added to their list.
 
 About Argo Books:
@@ -2451,7 +2486,12 @@ Return your response as JSON with two fields:
 Return ONLY the JSON, no other text.";
     }
 
-    if ($isEditorial) {
+    if ($isCreator) {
+        $details = "Creator / Publication: {$lead['business_name']}";
+        if (!empty($lead['contact_name'])) $details .= "\nName/handle: {$lead['contact_name']}";
+        if (!empty($lead['website'])) $details .= "\nProfile/channel URL: {$lead['website']}";
+        if ($summary) $details .= "\nContext (platform, audience, what they cover): $summary";
+    } elseif ($isEditorial) {
         $details = "Outlet / Publication: {$lead['business_name']}";
         if (!empty($lead['contact_name'])) $details .= "\nAuthor: {$lead['contact_name']}";
         if (!empty($lead['website'])) $details .= "\nArticle URL: {$lead['website']}";

--- a/cron/lib/shopify_discovery.php
+++ b/cron/lib/shopify_discovery.php
@@ -87,12 +87,16 @@ const SHOPIFY_DORK_POOL = [
  *                        is the most efficient single-call value)
  * @return array          Array of ['link'=>..., 'title'=>..., 'snippet'=>...] entries
  */
-function serpapi_query(string $query, string $apiKey, int $limit = 100): array
+function serpapi_query(string $query, string $apiKey, int $limit = 100, int $start = 0): array
 {
+    // $start is the organic-result offset (Google's `start` param): 0 = first
+    // page, $limit = second page, etc. Without it every call returns the same
+    // first page, so repeat runs only ever re-see already-imported results.
     $url = 'https://serpapi.com/search.json?engine=google'
         . '&q=' . urlencode($query)
         . '&api_key=' . urlencode($apiKey)
         . '&num=' . (int) $limit
+        . ($start > 0 ? '&start=' . (int) $start : '')
         . '&hl=en&gl=ca';
 
     $context = stream_context_create([
@@ -153,15 +157,16 @@ function serpapi_query(string $query, string $apiKey, int $limit = 100): array
  * Returns ['results' => array, 'from_cache' => bool]. Callers MUST only
  * increment the daily SerpAPI counter when from_cache is false.
  *
- * Cache key: SHA-256 of "{query}|num={limit}" so different limits don't
- * share cache entries. Empty result sets are NOT cached so transient SerpAPI
- * failures get retried on the next run instead of returning [] for 14 days.
+ * Cache key: SHA-256 of "{query}|num={limit}|start={start}" so different limits
+ * AND different result pages each get their own entry (otherwise page 2 would
+ * collide with page 1's cache). Empty result sets are NOT cached so transient
+ * SerpAPI failures get retried on the next run instead of returning [] for 14 days.
  */
 const SERPAPI_CACHE_TTL_DAYS = 14;
 
-function serpapi_query_cached(string $query, string $apiKey, int $limit, PDO $pdo): array
+function serpapi_query_cached(string $query, string $apiKey, int $limit, PDO $pdo, int $start = 0): array
 {
-    $cacheKey = hash('sha256', $query . '|num=' . $limit);
+    $cacheKey = hash('sha256', $query . '|num=' . $limit . '|start=' . $start);
 
     $stmt = $pdo->prepare(
         "SELECT response_json FROM serpapi_response_cache
@@ -179,7 +184,7 @@ function serpapi_query_cached(string $query, string $apiKey, int $limit, PDO $pd
     }
 
     // Cache miss → live SerpAPI call
-    $results = serpapi_query($query, $apiKey, $limit);
+    $results = serpapi_query($query, $apiKey, $limit, $start);
 
     // Only cache non-empty results. An empty array could be either a
     // legitimately empty result set or a transient HTTP/JSON failure,

--- a/cron/outreach_pipeline.php
+++ b/cron/outreach_pipeline.php
@@ -538,12 +538,29 @@ function stepDiscoverShopify($pdo, $dryRun)
 
         // Pick next dork and advance cursor immediately so failures don't get re-tried next dork
         $cursor = (int) getState($pdo, 'shopify_dork_cursor', '0');
-        $query = $dorkPool[$cursor % $totalDorks];
+        $idx = $cursor % $totalDorks;
+        $query = $dorkPool[$idx];
         setState($pdo, 'shopify_dork_cursor', (string) ($cursor + 1));
         $dorksTriedThisRun++;
         $queriesUsed[] = $query;
 
-        logPipeline("Shopify dork #$dorksTriedThisRun/$totalDorks (cursor=$cursor): '$query'");
+        // Per-dork page offset (shared with the admin Run button via the
+        // shopify_dork_pages state) so each pass pulls a DEEPER result page
+        // instead of re-reading page 1 and re-seeing already-imported stores.
+        // Capped by SHOPIFY_MAX_PAGE_DEPTH; a tapped-out dork is skipped (the
+        // $dorksTriedThisRun guard still terminates the loop).
+        $shopifyPages = json_decode(getState($pdo, 'shopify_dork_pages', '{}'), true);
+        if (!is_array($shopifyPages)) {
+            $shopifyPages = [];
+        }
+        $maxStart = (max(1, (int) ($_ENV['SHOPIFY_MAX_PAGE_DEPTH'] ?? 3)) - 1) * 100;
+        $start = (int) ($shopifyPages[(string) $idx] ?? 0);
+        if ($start > $maxStart) {
+            logPipeline("Dork '$query' past page-depth cap (start=$start). Skipping this pass.");
+            continue;
+        }
+
+        logPipeline("Shopify dork #$dorksTriedThisRun/$totalDorks (cursor=$cursor, page=" . (intdiv($start, 100) + 1) . "): '$query'");
 
         // SerpAPI call via 14-day response cache. Append global exclusions
         // so we don't pay for results that openly advertise being decades
@@ -551,7 +568,7 @@ function stepDiscoverShopify($pdo, $dryRun)
         // num=10 on SerpAPI, 10x the candidates per credit. Cache hits
         // do NOT consume daily SerpAPI quota.
         $queryWithExclusions = $query . SHOPIFY_DORK_EXCLUSIONS;
-        $queryResult = serpapi_query_cached($queryWithExclusions, $serpapiKey, 100, $pdo);
+        $queryResult = serpapi_query_cached($queryWithExclusions, $serpapiKey, 100, $pdo, $start);
         $results = $queryResult['results'];
         if ($queryResult['from_cache']) {
             logPipeline("'$query' served from SerpAPI cache (no credit spent).");
@@ -559,6 +576,9 @@ function stepDiscoverShopify($pdo, $dryRun)
             $serpapiCallsToday++;
             setState($pdo, 'serpapi_calls_today', (string) $serpapiCallsToday);
         }
+        // Advance this dork's page offset so the next pass goes deeper.
+        $shopifyPages[(string) $idx] = $start + 100;
+        setState($pdo, 'shopify_dork_pages', json_encode($shopifyPages));
 
         if (empty($results)) {
             logPipeline("SerpAPI returned no results for '$query'. Moving to next dork.");

--- a/mysql_schema.sql
+++ b/mysql_schema.sql
@@ -1108,6 +1108,29 @@ CREATE TABLE IF NOT EXISTS outreach_editorial_candidates (
     INDEX idx_lead (lead_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- Dedup/audit table for the Creators / affiliate-partner discovery channel
+-- (YouTubers, newsletter writers, niche bloggers, and LinkedIn profiles found by
+-- cron/lib/creator_discovery.php). Mirrors outreach_editorial_candidates: one row
+-- per canonical creator URL, status tracks imported/rejected so repeat runs skip
+-- already-handled candidates. platform records youtube/newsletter/blog/linkedin.
+CREATE TABLE IF NOT EXISTS outreach_creator_candidates (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    canonical_url VARCHAR(500) NOT NULL,
+    status ENUM('imported','rejected','error','pending') NOT NULL DEFAULT 'pending',
+    reject_reason VARCHAR(100) DEFAULT NULL,
+    reject_detail VARCHAR(500) DEFAULT NULL,
+    platform VARCHAR(20) DEFAULT NULL,
+    creator_name VARCHAR(150) DEFAULT NULL,
+    harvested_email VARCHAR(255) DEFAULT NULL,
+    lead_id INT DEFAULT NULL,
+    last_query VARCHAR(255) DEFAULT NULL,
+    checked_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_canonical_url (canonical_url),
+    INDEX idx_status_checked (status, checked_at),
+    INDEX idx_lead (lead_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- Key/value state for the outreach pipeline: master kill-switch
 -- (outreach_enabled), auto-send mode, follow-up sequence config, and other
 -- runtime flags. Read/written via getState/setState in cron/outreach_pipeline.php

--- a/tools/youtube-email-assist/README.md
+++ b/tools/youtube-email-assist/README.md
@@ -1,0 +1,79 @@
+# YouTube email assist
+
+A small local helper for the Creators (affiliate partners) outreach channel.
+
+YouTube hides a channel's business email behind a captcha, so it cannot be scraped
+automatically. This tool opens each channel's About page in a real browser window,
+you solve the captcha and reveal the email yourself, and it scrapes the revealed
+address and moves on. It is deliberately semi-manual: one captcha per channel is
+unavoidable, so run it for your best matches, not thousands.
+
+This runs on your machine, not the web server.
+
+## Install
+
+You need Node.js 18+.
+
+```
+cd tools/youtube-email-assist
+npm install
+npx playwright install chromium
+```
+
+## Get the list of channels to work
+
+In the admin Partners channel, the leads that came in without an email (mostly
+YouTubers) are the ones to run through this. Export them while logged in to admin
+by opening this URL in your browser and saving the response as `input.json`:
+
+```
+https://argorobots.com/admin/outreach/api.php?action=creator_export_emailless
+```
+
+The relevant part is the `leads` array. Save it as a JSON array shaped like:
+
+```json
+[
+  { "lead_id": 12, "url": "https://youtube.com/@somechannel" },
+  { "lead_id": 15, "url": "https://youtube.com/@another" }
+]
+```
+
+(Or skip the file entirely and pass URLs directly: `node assist.mjs --urls "https://youtube.com/@a,https://youtube.com/@b"`.)
+
+## Run it
+
+```
+node assist.mjs               # reads ./input.json, writes ./output.json
+node assist.mjs leads.json out.json
+```
+
+For each channel a browser window opens on the About page. Reveal the email
+(solve the captcha), then return to the terminal and:
+
+- press **Enter** to scrape the revealed email off the page, or
+- type the **email** to record it directly, or
+- type **s** to skip this channel.
+
+Progress is saved to `output.json` after every capture, so a crash never loses
+what you already did.
+
+## Apply the captured emails back to your leads
+
+`output.json` looks like `[{ "lead_id": 12, "url": "...", "email": "hi@channel.com" }]`.
+Send it to the admin `creator_set_email` action (while logged in to admin). For
+example with curl and your admin session cookie:
+
+```
+curl -X POST "https://argorobots.com/admin/outreach/api.php?action=creator_set_email" \
+  -H "Content-Type: application/json" \
+  -b "PHPSESSID=YOUR_ADMIN_SESSION" \
+  --data @output.json
+```
+
+Note: `creator_set_email` accepts either the raw array as `results`, or a single
+`{ "lead_id": 12, "email": "hi@channel.com" }`. It only fills leads that are still
+missing an email, so it is safe to re-run.
+
+Once a lead has an email, generate and send its affiliate pitch from the Partners
+→ Leads tab like any other lead.

--- a/tools/youtube-email-assist/assist.mjs
+++ b/tools/youtube-email-assist/assist.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Human-assisted YouTube channel email harvester.
+ *
+ * YouTube deliberately hides a channel's business email behind a captcha, so it
+ * cannot be scraped automatically. This tool does the next best thing: it opens
+ * each channel's About page in a REAL (headed) Chromium window, you solve the
+ * captcha and reveal the email yourself, then it scrapes the revealed address and
+ * moves to the next channel. It is deliberately semi-manual, one captcha per
+ * channel is unavoidable, so run it for your best matches, not thousands.
+ *
+ * Input:  a JSON file (default ./input.json) shaped like:
+ *           [{ "lead_id": 12, "url": "https://youtube.com/@somechannel" }, ...]
+ *         (creator_export_emailless in the admin API produces exactly this).
+ * Output: ./output.json with { lead_id, url, email } for the ones you captured,
+ *         which you can feed back via the admin creator_set_email action.
+ *
+ * Usage:
+ *   npm install
+ *   npx playwright install chromium
+ *   node assist.mjs                 # reads ./input.json, writes ./output.json
+ *   node assist.mjs leads.json out.json
+ *   node assist.mjs --urls "https://youtube.com/@a,https://youtube.com/@b"
+ *
+ * This is a local, personal-use helper. It does not run on the web server.
+ */
+
+import { chromium } from 'playwright';
+import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import readline from 'node:readline';
+
+const EMAIL_RE = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi;
+// Addresses that appear on YouTube chrome/consent pages but are never the
+// creator's contact email, filtered out of scrape results.
+const EMAIL_BLOCKLIST = [
+  'youtube.com', 'google.com', 'gmail-noreply', 'no-reply', 'noreply',
+  'example.com', 'sentry', 'schema.org',
+];
+
+function parseArgs(argv) {
+  const args = { input: 'input.json', output: 'output.json', urls: null };
+  const rest = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--urls') { args.urls = (argv[++i] || '').split(',').map(s => s.trim()).filter(Boolean); }
+    else rest.push(argv[i]);
+  }
+  if (rest[0]) args.input = rest[0];
+  if (rest[1]) args.output = rest[1];
+  return args;
+}
+
+async function loadTargets(args) {
+  if (args.urls && args.urls.length) {
+    return args.urls.map(url => ({ lead_id: null, url }));
+  }
+  if (!existsSync(args.input)) {
+    console.error(`Input file "${args.input}" not found. Create it as a JSON array of {lead_id, url}, or pass --urls "a,b".`);
+    process.exit(1);
+  }
+  const raw = await readFile(args.input, 'utf8');
+  let data;
+  try { data = JSON.parse(raw); } catch { console.error(`"${args.input}" is not valid JSON.`); process.exit(1); }
+  if (!Array.isArray(data)) { console.error('Input JSON must be an array.'); process.exit(1); }
+  return data.filter(d => d && d.url).map(d => ({ lead_id: d.lead_id ?? null, url: String(d.url) }));
+}
+
+/** Normalize a channel URL to its About page, where the email lives. */
+function toAboutUrl(url) {
+  try {
+    const u = new URL(url);
+    // Strip trailing slash, then append /about if not already an about/video URL.
+    let path = u.pathname.replace(/\/+$/, '');
+    if (/\/(watch|shorts|about)$/.test(path) || u.searchParams.has('v')) {
+      // A video URL: leave as-is; the user can navigate to the channel manually.
+      if (!/\/about$/.test(path)) return u.origin + path + u.search;
+    }
+    if (!/\/about$/.test(path)) path += '/about';
+    return u.origin + path;
+  } catch {
+    return url;
+  }
+}
+
+function scrapeEmailsFromText(text) {
+  const found = new Set();
+  for (const m of text.matchAll(EMAIL_RE)) {
+    const email = m[0].toLowerCase();
+    if (EMAIL_BLOCKLIST.some(b => email.includes(b))) continue;
+    found.add(email);
+  }
+  return [...found];
+}
+
+function ask(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => rl.question(question, ans => { rl.close(); resolve(ans.trim()); }));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const targets = await loadTargets(args);
+  if (!targets.length) { console.error('No target URLs.'); process.exit(1); }
+
+  console.log(`\nYouTube email assist: ${targets.length} channel(s).`);
+  console.log('A browser window will open on each channel. Solve the captcha and reveal the email,');
+  console.log('then come back here and press Enter. Type the email to override the scrape, or "s" to skip.\n');
+
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const results = [];
+  for (let i = 0; i < targets.length; i++) {
+    const t = targets[i];
+    const aboutUrl = toAboutUrl(t.url);
+    console.log(`\n[${i + 1}/${targets.length}] ${t.url}`);
+    try {
+      await page.goto(aboutUrl, { waitUntil: 'domcontentloaded', timeout: 45000 });
+    } catch (e) {
+      console.log(`  Could not load the page (${e.message}). You can still navigate manually in the window.`);
+    }
+
+    const answer = await ask('  Reveal the email in the window, then press Enter (or type the email / "s" to skip): ');
+    if (answer.toLowerCase() === 's') { console.log('  Skipped.'); continue; }
+
+    let email = '';
+    if (EMAIL_RE.test(answer)) {
+      EMAIL_RE.lastIndex = 0;
+      email = answer.match(EMAIL_RE)[0].toLowerCase();
+      console.log(`  Using typed email: ${email}`);
+    } else {
+      const body = await page.content();
+      const emails = scrapeEmailsFromText(body);
+      if (emails.length === 1) {
+        email = emails[0];
+        console.log(`  Scraped: ${email}`);
+      } else if (emails.length > 1) {
+        console.log(`  Found ${emails.length}: ${emails.join(', ')}`);
+        const pick = await ask('  Type the correct one (or Enter to take the first): ');
+        email = (pick && EMAIL_RE.test(pick)) ? pick.match(EMAIL_RE)[0].toLowerCase() : emails[0];
+        EMAIL_RE.lastIndex = 0;
+      } else {
+        console.log('  No email found on the page. Skipped.');
+        continue;
+      }
+    }
+    results.push({ lead_id: t.lead_id, url: t.url, email });
+    // Persist after each capture so a crash never loses progress.
+    await writeFile(args.output, JSON.stringify(results, null, 2), 'utf8');
+  }
+
+  await browser.close();
+  console.log(`\nDone. Captured ${results.length} email(s) -> ${args.output}`);
+  console.log('Apply them by feeding this file to the admin creator_set_email action (see README).');
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/tools/youtube-email-assist/package.json
+++ b/tools/youtube-email-assist/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "youtube-email-assist",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Human-assisted YouTube channel email harvester for the Argo Books Creators outreach channel. Opens each channel in a real browser, you solve the captcha, it scrapes the revealed email.",
+  "bin": {
+    "yt-email-assist": "assist.mjs"
+  },
+  "scripts": {
+    "start": "node assist.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.48.0"
+  }
+}


### PR DESCRIPTION
Overhauls the outreach discovery system and adds a new affiliate-partner channel. Built in phases, each its own commit.

## Phase 1 — Fix "runs find 0 results / everything is skipped"
Discovery was re-reading page 1 of each query (`serpapi_query` had no `start` offset), and that page was cached for 14 days, so once a query's first results were imported every rerun returned the same URLs and skipped them all.

- Add a `start` offset to `serpapi_query`/`serpapi_query_cached` (folded into the cache key so each page caches separately)
- Per-query page cursor persisted in `outreach_pipeline_state`; pre-dedup before the AI step
- Editorial and Shopify runs are now resumable **target-count loops**: keep paging/rotating until the requested import count, bounded by a per-run SerpAPI budget, an AI-eval cap, a time limit, and a dry-streak exhaustion exit; report `stop_reason`/`found_count`

## Phase 2 — Partners channel (affiliate-partner discovery)
Finds YouTubers, newsletter writers, and niche bloggers whose audience fits Argo Books, and pitches the affiliate program (50% recurring).

- New `cron/lib/creator_discovery.php` reusing the shared SerpAPI + scrape + Gemini infra and the Phase-1 loop; classifies platform (youtube/newsletter/blog/linkedin)
- `outreach_creator_candidates` table; affiliate-recruitment draft branch (`source=creator_auto`); leads kept out of the Email tab
- New **Partners** channel tab: Discovery (target-count Run + add-by-URL) and Leads (same filters + bulk Draft/Send/Delete as the other channels)
- LinkedIn is a URL-only manual list (can't be scraped)

## Phase 3 — Assisted YouTube email helper
YouTube hides channel emails behind a captcha.

- Local Playwright tool (`tools/youtube-email-assist`): opens each channel, you solve the captcha, it scrapes the revealed email
- Admin endpoints `creator_export_emailless` (seed the helper) and `creator_set_email` (apply captured emails back, only filling leads still missing one)

## Deploy step (required)
Run the new `outreach_creator_candidates` table on the server (in `mysql_schema.sql`) before merging goes live.

## Testing notes
All PHP/JS files lint clean; the affiliate detector and pagination logic were exercised directly. Local MySQL was down during development, so the DB-backed discovery flows were **not** run end-to-end — do one editorial Run and one Partners Run against a live DB before relying on it.

Env knobs (`SERPAPI_MAX_CALLS_PER_RUN`, `CREATOR_MAX_PAGE_DEPTH`, `OUTREACH_CREATOR_ENABLED`, etc.) were added to the gitignored `.env` files locally; the code has sensible defaults so they're optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
